### PR TITLE
feat: passing data from form states to post request body

### DIFF
--- a/src/components/forms/RegistrationWizard.tsx
+++ b/src/components/forms/RegistrationWizard.tsx
@@ -317,6 +317,29 @@ export default function RegistrationWizard() {
   };
 
   const onSubmit = async () => {
+    const payload: any = {};
+    
+    //post condition if using guardian or parent
+    if (useGuardian) {
+      payload.guardian = {
+        first_name: guardianFname,
+        last_name: guardianLname,
+      }; 
+    } else {
+      payload.parent = {
+        father: {
+          first_name: fatherFname,
+          last_name: fatherLname,
+          middle_name: fatherMname,
+          suffix: fatherSuffix,
+        },
+        mother: {
+          first_name: motherFname,
+          last_name: motherLname,
+          middle_name: motherMname,
+        },
+      };
+    }
 
     const body = {
       id: idNumber,
@@ -333,23 +356,7 @@ export default function RegistrationWizard() {
         major: selectedMajor,
         thesis: thesisTitle,
       },
-      guardian: {
-        first_name: guardianFname,
-        last_name: guardianLname,
-      },
-      parent: {
-        father: {
-          first_name: fatherFname,
-          last_name: fatherLname,
-          middle_name: fatherMname,
-          suffix: fatherSuffix,
-        },
-        mother: {
-          first_name: motherFname,
-          last_name: motherLname,
-          middle_name: motherMname,
-        },
-      }
+      ...payload, //could be either guardian or parent
     };
 
     try {


### PR DESCRIPTION
This pull request enhances the `RegistrationWizard` component by implementing a more robust and dynamic payload construction for the registration form submission. The changes ensure that the correct guardian or parent information is included based on user selection, and the payload now accurately reflects all relevant user input fields.

**Form submission enhancements:**

* Refactored the `onSubmit` function to dynamically build a `payload` object, including either `guardian` or `parent` information depending on the `useGuardian` flag.
* Updated the main `body` object in the submission to include all relevant registration fields such as `personal_email`, `school_email`, full name, nickname, birthdate, and academic details, replacing previous hardcoded sample data.

 Please use "**Squash and Merge**" when merging for cleaner commit history thanks :D
 (or it'll be a hell to revert changes later on)