### PR TITLE
refactor: include adresses to request body and rename payload object

### DIFF
--- a/src/components/forms/RegistrationWizard.tsx
+++ b/src/components/forms/RegistrationWizard.tsx
@@ -331,16 +331,16 @@ export default function RegistrationWizard() {
   };
 
   const onSubmit = async () => {
-    const payload: any = {};
+    const relation: any = {};
     
     //post condition if using guardian or parent
     if (useGuardian) {
-      payload.guardian = {
+      relation.guardian = {
         first_name: guardianFname,
         last_name: guardianLname,
       }; 
     } else {
-      payload.parent = {
+      relation.parent = {
         father: {
           first_name: fatherFname,
           last_name: fatherLname,
@@ -363,15 +363,17 @@ export default function RegistrationWizard() {
       first_name: fname,
       middle_name: mname,
       suffix: suffix,
-      // FIX: Ensure quotes are added upon submission
-      nickname: getFormattedNickname(), 
+      nickname: nickname,
       birthdate: bdate,
       academics: {
         course: selectedCourse,
         major: selectedMajor,
         thesis: thesisTitle,
       },
-      ...payload, 
+      ...relation, 
+      province: provinceName,
+      city: cityName,
+      barangary: barangayName 
     };
 
     try {


### PR DESCRIPTION
This pull request updates the `RegistrationWizard` form submission logic to improve how relational data is structured and to ensure additional address fields are included in the submission payload. The main changes focus on renaming the variable that stores guardian/parent information, updating how the nickname is handled, and adding address details to the payload.

Form data restructuring and improvements:

* Changed the variable name from `payload` to `relation` for storing guardian or parent information to better reflect its purpose.
* Updated the submission payload to spread `relation` instead of `payload`, and added `province`, `city`, and `barangay` fields to ensure address information is included in the form submission.

Form field handling:

* Modified the `nickname` field to use the raw `nickname` value instead of the result of `getFormattedNickname()`, simplifying the nickname submission.