### PR TITLE
feat: logout session through endpoint request

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Image from "next/image"; 
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Bell, Menu } from "lucide-react";
 
@@ -16,6 +17,8 @@ import { SchedulesTab } from "@/components/admin/tabs/SchedulesTab";
 import * as adminService from "@/app/admin/adminService";
 
 export default function AdminDashboard() {
+  const router = useRouter();
+
   const [activeTab, setActiveTab] = useState("verification"); 
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [pendingStudents, setPendingStudents] = useState<any[]>([]);
@@ -47,6 +50,16 @@ export default function AdminDashboard() {
     }
   }
 
+  const onLogout = async () => {
+    const res = await fetch("http://localhost:4000/api/auth/logout", {
+      credentials: 'include'
+    });
+
+    if (res.ok) {
+      router.push('/');
+    }
+  }
+
   return (
     <div className="min-h-screen bg-stone-50 flex font-sans relative">
       
@@ -58,7 +71,7 @@ export default function AdminDashboard() {
                 isMobile={true} 
                 setIsOpen={setIsMobileMenuOpen} 
                 user={staffUser} 
-                onLogout={() => localStorage.removeItem("aurium_admin_session")}
+                onLogout={() => onLogout()}
              />
          </div>
       )}
@@ -68,7 +81,7 @@ export default function AdminDashboard() {
         setActiveTab={setActiveTab} 
         isMobile={false} 
         user={staffUser} 
-        onLogout={() => {}}
+        onLogout={() => onLogout()}
       />
 
       {/* FIXED: Removed 'h-screen', 'overflow-y-auto' and scrollbar hacks.

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation"; // <--- Needed for routing
+import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Lock, Mail, ArrowRight, Loader2, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
This pull request updates the admin dashboard's logout functionality to ensure a proper server-side logout and redirect, replacing the previous local-only session removal. The logout logic is now centralized and correctly navigates the user to the homepage upon successful logout.

Authentication and logout improvements:

* Added an `onLogout` function in `AdminDashboard` that calls the backend logout API and, upon success, redirects the user to the homepage using `router.push('/')`. This replaces the previous approach that only removed a local storage item. (`src/app/admin/dashboard/page.tsx`)
* Updated both mobile and desktop admin navigation components to use the new `onLogout` function, ensuring consistent logout behavior across the dashboard. (`src/app/admin/dashboard/page.tsx`)