### PR TITLE
feat: add schedule through request (partial, no fetching yet) 

### DIFF
--- a/src/app/admin/adminService.tsx
+++ b/src/app/admin/adminService.tsx
@@ -34,3 +34,41 @@ export async function handleVerify(studentId: number) {
         return false;
     }
 };
+
+export async function addSchedule(date: string, am_cap: number, pm_cap: number) {
+    const body = { 
+        date: date, 
+        am_cap: am_cap, 
+        pm_cap: pm_cap 
+    };
+
+    try {
+        const res = await fetch("http://localhost:4000/api/admin/book/add", {
+            method: 'POST',
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+            credentials: 'include'
+        });
+
+        if (!res.ok) {
+            //duplicate handler (explicitly 409)
+            if (res.status == 409) {
+                const err_body = await res.json();
+                return {
+                    success: false,
+                    reason: err_body.reason
+                };
+            }
+            
+            return { 
+                success: false, 
+                reason: "Something went wrong in the server" 
+            };
+        }
+        return { success: true };
+
+    } catch(err) {
+        console.error("Server error: ", err);
+        return { success: false };
+    }
+}

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import * as adminService from "@/app/admin/adminService"
 
 // helper ra ni nako to generate fake names para sa roster ni koi
 const generateMockStudents = (count: number) => {
@@ -75,14 +76,14 @@ export function useSchedules() {
     setIsEditCapacityOpen(true);
   };
 
-  // function para mo open ang roster ni koi
+  //show roster
   const openRosterDialog = (date: string, session: 'am'|'pm', students: any[]) => {
     setActiveRoster({ date, session, students });
     setIsRosterOpen(true);
   };
 
-  // logic inig create ug bag-ong schedule
-  const handleAddNewDate = () => {
+  //handle add date
+  const handleAddNewDate = async () => {
     if (!newDateInput) return;
     const exists = schedules.some(s => s.date === newDateInput);
     if (exists) { alert("Date already exists!"); return; }
@@ -90,24 +91,29 @@ export function useSchedules() {
     const amLimit = (sessionType === 'both' || sessionType === 'am') ? newAmCapacity : 0;
     const pmLimit = (sessionType === 'both' || sessionType === 'pm') ? newPmCapacity : 0;
 
-    const newSchedule = { 
-        date: newDateInput, 
-        amSlots: amLimit, 
-        amStudents: [], // blank roster initially
-        pmSlots: pmLimit, 
-        pmStudents: [] 
-    };
+    try {
+      const res = await adminService.addSchedule(newDateInput, amLimit, pmLimit);
+      if (res.success) {
 
-    setSchedules(prev => [...prev, newSchedule].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()));
-    
-    // reset form fields
-    setNewDateInput(""); 
-    setNewAmCapacity(50);
-    setNewPmCapacity(50);
-    setIsAddDateOpen(false);
+        alert("New schedule has been added succesfully!");
+        
+        //TODO: re-fetch to update local state
+
+        // reset form fields
+        setNewDateInput("");
+        setNewAmCapacity(0);
+        setNewPmCapacity(0);
+        setIsAddDateOpen(false);
+      } else {
+        alert(res.reason);
+      }
+    } catch(err) {
+      console.error("Error adding schedule", err);
+      alert("Error connecting to the server");
+    }
   };
 
-  // setter para sa manual add dialog
+  //manaually add student based on id number
   const openAddStudentDialog = (date: string, session: 'am'|'pm') => {
       setActiveAddStudentSession({ date, session });
       setManualStudentId("");
@@ -152,7 +158,7 @@ export function useSchedules() {
     isAddDateOpen, setIsAddDateOpen,
     manualStudentId, setManualStudentId,
     isAddStudentOpen, setIsAddStudentOpen,
-    activeAddStudentSession, // <--- I-ADD NI DIRI
+    activeAddStudentSession,
     isEditCapacityOpen, setIsEditCapacityOpen,
     editingCapacity, setEditingCapacity,
     isRosterOpen, setIsRosterOpen,


### PR DESCRIPTION
This pull request introduces a new feature for adding schedules to the admin system and updates the schedule management logic to interact with the backend. The main changes include creating an `addSchedule` function in `adminService.tsx` and refactoring the schedule addition logic in the `useSchedules` hook to use this new backend API. These updates improve error handling, ensure backend consistency, and reset form fields appropriately.

**Backend integration for schedule management:**

* Added the `addSchedule` function in `adminService.tsx` to handle creating new schedules by sending a POST request to the backend, including error handling for duplicate dates and server errors.
* Refactored the `handleAddNewDate` function in `useSchedules` to use the new `adminService.addSchedule` API, improving error handling and ensuring schedules are added via the backend rather than locally.

**Code organization and usability improvements:**

* Imported `adminService` in `useSchedules.ts` to enable backend communication for schedule management.
* Reset form fields (`newAmCapacity`, `newPmCapacity`) to zero instead of 50 after adding a schedule, ensuring the form is cleared for the next entry.
* Minor cleanup: removed unnecessary comments and ensured consistent naming and state management in the `useSchedules` hook.