### PR TITLE
refactor redundant student number query to use jwt payload

### DIFF
--- a/src/app/student/dashboard/page.tsx
+++ b/src/app/student/dashboard/page.tsx
@@ -45,8 +45,8 @@ export default function StudentDashboard() {
     fetchSchedules();
   }, [fetchStudent, fetchSchedules]);
 
-  const handleBooking = async (student_number: string, booking_id: number, period: string) => {
-    const res = await studentService.addBook(student_number, booking_id, period)
+  const handleBooking = async (booking_id: number, period: string) => {
+    const res = await studentService.addBook(booking_id, period)
 
     //TODO: optimize..
     if (!res) {

--- a/src/app/student/studentService.tsx
+++ b/src/app/student/studentService.tsx
@@ -36,13 +36,12 @@ export async function fetchSchedules() {
     }
 };
 
-export async function addBook(student_id: string, booking_id: number, period: string) {
+export async function addBook(booking_id: number, period: string) {
     try {
         const res = await fetch("http://localhost:4000/api/student/book/create", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-                student_number: parseInt(student_id),
                 booking_id: booking_id,
                 period: period
             }),

--- a/src/components/student/dashboard/BookingWidget.tsx
+++ b/src/components/student/dashboard/BookingWidget.tsx
@@ -13,7 +13,7 @@ interface BookingWidgetProps {
   bookingList: Schedule[], 
   booking: any,
   idNumber: string;
-  onBook: (student_number: string, booking_id: number, period: string) => void;
+  onBook: (booking_id: number, period: string) => void;
 };
 
 export function BookingWidget({ bookingList, booking, idNumber, onBook }: BookingWidgetProps) {
@@ -32,7 +32,7 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
 
   const handleConfirm = () => {
     if (selectedDate && selectedSession) {
-        onBook(idNumber, selectedBookingId, selectedSession);
+        onBook(selectedBookingId, selectedSession);
         setIsConfirmDialogOpen(false);
         setIsBookingModalOpen(false);
     }


### PR DESCRIPTION
This pull request refactors the booking functionality in the student dashboard to simplify the booking flow by removing the need to pass the student's ID number to booking-related functions. The changes update function signatures and calls throughout the relevant components and service files.

Booking flow simplification:

* Changed the `addBook` function in `studentService.tsx` to no longer require the `student_id` parameter, removing it from both the function signature and the request body.
* Updated the `handleBooking` function in `StudentDashboard` to match the new `addBook` signature, removing the `student_number` argument.
* Modified the `BookingWidgetProps` interface and the `onBook` callback throughout `BookingWidget.tsx` to remove the `student_number` parameter, ensuring consistency in type definitions and function calls.