### PR TITLE
fix reg routing and refac department names

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -192,7 +192,7 @@ export default function StudentLoginPage() {
                         <CardFooter className="justify-center pb-8 border-t border-stone-100 pt-6">
                             <p className="text-sm text-stone-500">
                                 Don't have an account?{' '}
-                                <Link href="/register" className="font-bold text-amber-700 hover:underline">
+                                <Link href="/auth/register" className="font-bold text-amber-700 hover:underline">
                                     Register here
                                 </Link>
                             </p>

--- a/src/components/forms/RegistrationWizard.tsx
+++ b/src/components/forms/RegistrationWizard.tsx
@@ -36,7 +36,7 @@ const departmentOptions = [
     ]
   },
   {
-    name: "DEPARTMENT OF ART AND SCIENCES EDUCATION",
+    name: "DEPARTMENT OF ARTS AND SCIENCES EDUCATION",
     courses: [
       { name: "BACHELOR OF ARTS IN ENGLISH", majors: [] },
       { name: "BACHELOR OF SCIENCE IN PSYCHOLOGY", majors: [] }
@@ -75,7 +75,7 @@ const departmentOptions = [
     ]
   },
   {
-    name: "HOSPITALITY AND TOURISM MANAGEMENT EDUCATION",
+    name: "DEPARTMENT OF HOSPITALITY EDUCATION",
     courses: [
       { name: "BACHELOR OF SCIENCE IN HOSPITALITY MANAGEMENT", majors: [] },
       { name: "BACHELOR OF SCIENCE IN HOTEL AND RESTAURANT MANAGEMENT", majors: [] },


### PR DESCRIPTION
This pull request makes several updates to improve accuracy and consistency in department naming and navigation within the registration and login flows. The most important changes are grouped below:

Navigation update:

* Changed the registration link in the student login page to point to `/auth/register` instead of `/register`, ensuring correct routing for new users.

Department naming corrections (RegistrationWizard):

* Corrected the department name from `"DEPARTMENT OF ART AND SCIENCES EDUCATION"` to `"DEPARTMENT OF ARTS AND SCIENCES EDUCATION"` for clarity and accuracy.
* Updated the department name from `"HOSPITALITY AND TOURISM MANAGEMENT EDUCATION"` to `"DEPARTMENT OF HOSPITALITY EDUCATION"` for consistency with other department names.