### PR TITLE
fix: domain to use subdomain instead

### DIFF
--- a/src/app/student/dashboard/page.tsx
+++ b/src/app/student/dashboard/page.tsx
@@ -32,7 +32,7 @@ export default function StudentDashboard() {
     const idx = url.indexOf(findStr);
 
     if (idx === -1) return "";
-    return "https://auriumi.cloud/" + url.substring(idx + findStr.length);
+    return "https://static.auriumi.cloud/" + url.substring(idx + findStr.length);
   }
 
   const fetchStudent = useCallback(async () => {


### PR DESCRIPTION
This pull request makes a minor update to the URL returned by the `StudentDashboard` component. The change updates the base URL from `auriumi.cloud` to `static.auriumi.cloud` to likely reflect a new or more accurate static asset host.