### PR TITLE
refactor: implement lazy loading and server-side pagination for Masterlist

### DIFF
--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -1,44 +1,61 @@
 "use client";
 
 import { useState } from "react";
-import { Search, BookOpen, GraduationCap, FileText, MapPin, Phone, Mail, ChevronRight, Clock, ChevronDown, ChevronUp, Filter, FolderOpen, Folder, User, Image as ImageIcon, X, Home, CreditCard, Building2, ListFilter, ChevronLeft } from "lucide-react";
+// Added Loader2 for the fetching state
+import { Search, BookOpen, GraduationCap, FileText, MapPin, Phone, Mail, ChevronRight, Clock, ChevronDown, ChevronUp, Filter, FolderOpen, Folder, User, Image as ImageIcon, X, Home, CreditCard, Building2, ListFilter, ChevronLeft, Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 import { useMasterlist } from "@/hooks/useMasterlist";
 
-// Koi, butangan nakog studentsData prop dire para dritso ra nimo isalpak ang array from DB inig test nimo
-export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
+// @Koi: Removed the studentsData prop. We no longer pass the heavy array from the parent.
+// The component now relies entirely on the useMasterlist hook to fetch data dynamically.
+export function MasterlistTab() {
   
-  // gi pasa nako ang data padulong sa hook aron didto ra tuyokon ang logic ug filtering para limpyo atong component
+  // Extracting our new lazy-loading states and functions from the hook
   const {
     searchQuery, setSearchQuery, selectedStudent, setSelectedStudent,
     activeDeptFilter, setActiveDeptFilter, activeStatusFilter, setActiveStatusFilter,  
-    expandedDepts, toggleDept, processedData, DEPARTMENT_ORDER, STATUS_STEPS
-  } = useMasterlist(studentsData);
+    expandedDepts, toggleDept, 
+    summaryData, isLoadingSummary, courseStudentsCache, fetchCourseStudents, 
+    DEPARTMENT_ORDER, STATUS_STEPS
+  } = useMasterlist();
 
-  // set up local states para sa course folders ug sa pagination per course
+  // Local states for course folders and their respective current pages
   const [expandedCourses, setExpandedCourses] = useState<string[]>([]);
   const [coursePages, setCoursePages] = useState<Record<string, number>>({});
   
-  // set to 9 students per page ni aron perpekto ang 3x3 grid nato sa UI, di bati tan-awon
+  // Set to 9 students per page to maintain the perfect 3x3 grid layout in the UI
   const ITEMS_PER_PAGE = 9; 
 
-  // fn para ma open/close ang course tapos i-reset ang pagination to page 1 always inig open
+  // @Koi: Updated this function. When a course folder is clicked, it now triggers 
+  // the API fetch for Page 1 of that specific course to load the initial students.
   const toggleCourse = (courseName: string) => {
-      setExpandedCourses(prev => 
-          prev.includes(courseName) ? prev.filter(c => c !== courseName) : [...prev, courseName]
-      );
+      setExpandedCourses(prev => {
+        const isClosing = prev.includes(courseName);
+        if (isClosing) return prev.filter(c => c !== courseName);
+        
+        // Fetch data from backend when opening the folder for the first time
+        fetchCourseStudents(courseName, 1, ITEMS_PER_PAGE);
+        return [...prev, courseName];
+      });
+
       if (!coursePages[courseName]) {
           setCoursePages(prev => ({...prev, [courseName]: 1}));
       }
   };
 
-  // helper aron ma generate ang saktong page numbers per course
+  // @Koi: Helper function to handle page changes. It updates the local page state 
+  // and simultaneously calls your backend to fetch the specific page data.
+  const handlePageChange = (courseName: string, pageNum: number) => {
+      setCoursePages(p => ({...p, [courseName]: pageNum}));
+      fetchCourseStudents(courseName, pageNum, ITEMS_PER_PAGE);
+  };
+
+  // Helper to generate dynamic page numbers (e.g., 1 2 3 4 5)
   const getCoursePageNumbers = (courseName: string, totalPages: number) => {
       const current = coursePages[courseName] || 1;
       const pages = [];
@@ -49,7 +66,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
       return pages;
   };
 
-  // helper component aron di sige copy-paste ug code sa mga info fields sa modal
+  // Reusable UI component for displaying information fields inside the modal
   const InfoField = ({ label, value, icon: Icon, fullWidth = false }: any) => (
     <div className={`flex flex-col space-y-1 ${fullWidth ? "col-span-2" : "col-span-1"}`}>
         <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider flex items-center gap-1.5">
@@ -76,7 +93,8 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                     </p>
                 </div>
                 <Badge variant="secondary" className="bg-amber-100 text-amber-800 border-amber-200 px-4 py-1.5 text-sm h-fit">
-                    {processedData.totalResults} Records Found
+                    {/* @Koi: totalResults now comes from the lightweight summary endpoint */}
+                    {isLoadingSummary ? "Loading..." : `${summaryData.totalResults || 0} Records Found`}
                 </Badge>
             </div>
             
@@ -135,7 +153,14 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
 
         {/* --- Main List (Departments -> Courses -> Students) --- */}
         <div className="space-y-4 pb-10 min-h-[400px]">
-            {processedData.sortedDepts.length === 0 && (
+            {isLoadingSummary && (
+                <div className="text-center py-16 text-stone-400 bg-stone-50 rounded-2xl border border-dashed border-stone-200 flex flex-col items-center">
+                    <Loader2 className="h-8 w-8 mb-4 text-amber-500 animate-spin"/>
+                    <p className="text-sm font-medium">Fetching database summary...</p>
+                </div>
+            )}
+
+            {!isLoadingSummary && summaryData.sortedDepts.length === 0 && (
                 <div className="text-center py-16 text-stone-400 bg-stone-50 rounded-2xl border border-dashed border-stone-200 flex flex-col items-center">
                     <Search className="h-12 w-12 mb-4 opacity-20"/>
                     <p className="text-lg font-medium text-stone-500">No records found</p>
@@ -143,7 +168,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                 </div>
             )}
 
-            {processedData.sortedDepts.map((dept) => {
+            {!isLoadingSummary && summaryData.sortedDepts.map((dept: string) => {
                 const isExpanded = expandedDepts.includes(dept);
                 return (
                     <div key={dept} className="bg-white rounded-xl border border-stone-200 shadow-sm overflow-hidden transition-all duration-200">
@@ -158,7 +183,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                             </div>
                             <div className="flex items-center gap-4">
                                 <Badge variant="outline" className="text-xs font-mono text-stone-500 border-stone-200 bg-white">
-                                    {processedData.deptCounts[dept]} Students
+                                    {summaryData.deptCounts[dept] || 0} Students
                                 </Badge>
                                 {isExpanded ? <ChevronUp className="h-4 w-4 text-stone-400" /> : <ChevronDown className="h-4 w-4 text-stone-400" />}
                             </div>
@@ -167,14 +192,20 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                         {/* Department Body (List of Courses) */}
                         {isExpanded && (
                             <div className="p-4 space-y-4 bg-[#FDFBF7]/30 animate-in slide-in-from-top-2 duration-200">
-                                {Object.keys(processedData.groups[dept]).sort().map((program) => {
+                                {Object.keys(summaryData.groups[dept] || {}).sort().map((program) => {
                                     
                                     const isCourseExpanded = expandedCourses.includes(program);
-                                    const studentsInCourse = processedData.groups[dept][program].sort((a, b) => a.lname.localeCompare(b.lname));
+                                    
+                                    // @Koi: Expecting summaryData.groups[dept][program] to be an integer representing the total count of students in this course
+                                    const studentCount = typeof summaryData.groups[dept][program] === 'number' ? summaryData.groups[dept][program] : (summaryData.groups[dept][program]?.length || 0);
                                     
                                     const currentPage = coursePages[program] || 1;
-                                    const totalPages = Math.ceil(studentsInCourse.length / ITEMS_PER_PAGE) || 1;
-                                    const paginatedStudents = studentsInCourse.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
+                                    const totalPages = Math.ceil(studentCount / ITEMS_PER_PAGE) || 1;
+                                    
+                                    // @Koi: We extract the exact paginated students from the cache based on course and page number
+                                    const cacheKey = `${program}-page-${currentPage}`;
+                                    const paginatedStudents = courseStudentsCache[cacheKey] || [];
+                                    const isLoadingStudents = isCourseExpanded && paginatedStudents.length === 0 && studentCount > 0;
 
                                     return (
                                         <div key={program} className="bg-white border border-stone-200 rounded-lg overflow-hidden shadow-sm">
@@ -191,7 +222,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                                                     </h4>
                                                 </div>
                                                 <div className="flex items-center gap-3 pr-2">
-                                                    <span className="text-[10px] font-bold text-stone-400">{studentsInCourse.length} records</span>
+                                                    <span className="text-[10px] font-bold text-stone-400">{studentCount} records</span>
                                                     {isCourseExpanded ? <ChevronUp size={14} className="text-amber-600"/> : <ChevronDown size={14} className="text-stone-400"/>}
                                                 </div>
                                             </div>
@@ -199,40 +230,47 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                                             {/* Students Grid + Pagination per course */}
                                             {isCourseExpanded && (
                                                 <div className="p-4 bg-stone-50/30 animate-in fade-in duration-200">
-                                                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                                                        {paginatedStudents.map((student) => {
-                                                            const statusInfo = STATUS_STEPS.find(s => s.id === student.statusStep) || STATUS_STEPS[0];
-                                                            
-                                                            return (
-                                                                <div 
-                                                                    key={student.id} 
-                                                                    onClick={() => setSelectedStudent(student)} 
-                                                                    className="group bg-white p-3.5 rounded-lg border border-stone-200 hover:border-amber-400 hover:shadow-md transition-all cursor-pointer flex justify-between items-center relative overflow-hidden"
-                                                                >
-                                                                    <div className="absolute left-0 top-0 bottom-0 w-1 bg-amber-500 opacity-0 group-hover:opacity-100 transition-opacity"></div>
-                                                                    <div className="relative z-10 w-full">
-                                                                        <div className="flex justify-between items-start mb-1">
-                                                                            <p className="font-bold text-stone-800 group-hover:text-amber-800 transition-colors text-sm truncate pr-2">
-                                                                                {student.lname}, {student.fname} {student.mname?.charAt(0) ? `${student.mname.charAt(0)}.` : ""} {student.suffix}
-                                                                            </p>
-                                                                            <div className={`w-2 h-2 rounded-full flex-shrink-0 mt-1.5 ${statusInfo.color}`} title={statusInfo.label}></div>
-                                                                        </div>
-                                                                        <div className="flex justify-between items-center">
-                                                                            <p className="text-[11px] font-mono text-stone-500">{student.idNumber}</p>
-                                                                            <span className="text-[9px] text-stone-400 font-medium uppercase">{statusInfo.label}</span>
+                                                    {isLoadingStudents ? (
+                                                        <div className="flex justify-center items-center py-8">
+                                                            <Loader2 className="h-6 w-6 text-amber-500 animate-spin" />
+                                                            <span className="ml-2 text-xs text-stone-500">Fetching students...</span>
+                                                        </div>
+                                                    ) : (
+                                                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                                                            {paginatedStudents.map((student: any) => {
+                                                                const statusInfo = STATUS_STEPS.find(s => s.id === student.statusStep) || STATUS_STEPS[0];
+                                                                
+                                                                return (
+                                                                    <div 
+                                                                        key={student.id} 
+                                                                        onClick={() => setSelectedStudent(student)} 
+                                                                        className="group bg-white p-3.5 rounded-lg border border-stone-200 hover:border-amber-400 hover:shadow-md transition-all cursor-pointer flex justify-between items-center relative overflow-hidden"
+                                                                    >
+                                                                        <div className="absolute left-0 top-0 bottom-0 w-1 bg-amber-500 opacity-0 group-hover:opacity-100 transition-opacity"></div>
+                                                                        <div className="relative z-10 w-full">
+                                                                            <div className="flex justify-between items-start mb-1">
+                                                                                <p className="font-bold text-stone-800 group-hover:text-amber-800 transition-colors text-sm truncate pr-2">
+                                                                                    {student.lname}, {student.fname} {student.mname?.charAt(0) ? `${student.mname.charAt(0)}.` : ""} {student.suffix}
+                                                                                </p>
+                                                                                <div className={`w-2 h-2 rounded-full flex-shrink-0 mt-1.5 ${statusInfo.color}`} title={statusInfo.label}></div>
+                                                                            </div>
+                                                                            <div className="flex justify-between items-center">
+                                                                                <p className="text-[11px] font-mono text-stone-500">{student.idNumber}</p>
+                                                                                <span className="text-[9px] text-stone-400 font-medium uppercase">{statusInfo.label}</span>
+                                                                            </div>
                                                                         </div>
                                                                     </div>
-                                                                </div>
-                                                            )
-                                                        })}
-                                                    </div>
+                                                                )
+                                                            })}
+                                                        </div>
+                                                    )}
 
                                                     {/* Pagination Controls per Course */}
                                                     {totalPages > 1 && (
                                                         <div className="flex items-center justify-between mt-4 pt-4 border-t border-stone-100">
                                                             <Button 
                                                                 variant="outline" size="icon" className="h-7 w-7" 
-                                                                onClick={() => setCoursePages(p => ({...p, [program]: Math.max(1, currentPage - 1)}))}
+                                                                onClick={() => handlePageChange(program, Math.max(1, currentPage - 1))}
                                                                 disabled={currentPage === 1}
                                                             >
                                                                 <ChevronLeft className="h-3 w-3" />
@@ -244,7 +282,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
                                                                         key={pageNum}
                                                                         variant={currentPage === pageNum ? "default" : "ghost"}
                                                                         className={`h-7 w-7 text-[10px] ${currentPage === pageNum ? 'bg-amber-600 hover:bg-amber-700' : ''}`}
-                                                                        onClick={() => setCoursePages(p => ({...p, [program]: pageNum}))}
+                                                                        onClick={() => handlePageChange(program, pageNum)}
                                                                     >
                                                                         {pageNum}
                                                                     </Button>
@@ -253,7 +291,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
 
                                                             <Button 
                                                                 variant="outline" size="icon" className="h-7 w-7"
-                                                                onClick={() => setCoursePages(p => ({...p, [program]: Math.min(totalPages, currentPage + 1)}))}
+                                                                onClick={() => handlePageChange(program, Math.min(totalPages, currentPage + 1))}
                                                                 disabled={currentPage === totalPages}
                                                             >
                                                                 <ChevronRight className="h-3 w-3" />
@@ -272,7 +310,7 @@ export function MasterlistTab({ studentsData = [] }: { studentsData?: any[] }) {
             })}
         </div>
 
-        {/* --- PROFILE MODAL: Mugawas ni kung naay gi-click nga student --- */}
+        {/* --- PROFILE MODAL: Remains unchanged --- */}
         <Dialog open={!!selectedStudent} onOpenChange={(open) => !open && setSelectedStudent(null)}>
             <DialogContent className="max-w-[95vw] md:max-w-7xl h-[92vh] p-0 overflow-hidden rounded-xl border-0 shadow-2xl bg-white flex flex-col md:flex-row [&>button]:hidden">
                 <div className="sr-only">

--- a/src/hooks/useMasterlist.ts
+++ b/src/hooks/useMasterlist.ts
@@ -1,7 +1,6 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect } from "react";
 
 // --- 1. CONFIGURATIONS ---
-// @Koi: Ako nani gi set daan ang mga departments ug majors nato para magamit sa dropdown filters sa UI
 export const ACADEMIC_CONFIG = [
   {
     name: "GRADUATE SCHOOL",
@@ -79,7 +78,6 @@ export const ACADEMIC_CONFIG = [
   }
 ];
 
-// @Koi: Base sa imong request, kani na ang imong 1-5 tracking steps
 export const STATUS_STEPS = [
   { id: 1, label: "Registered", color: "bg-stone-500" },      
   { id: 2, label: "Approved", color: "bg-blue-500" },        
@@ -90,87 +88,109 @@ export const STATUS_STEPS = [
 
 export const DEPARTMENT_ORDER = ACADEMIC_CONFIG.map(d => d.name);
 
-export function useMasterlist(studentsData: any[]) {
+// Notice: We no longer accept 'studentsData' array. We will fetch dynamically.
+export function useMasterlist() {
+  // --- UI STATES ---
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [selectedStudent, setSelectedStudent] = useState<any>(null);
   
   const [activeDeptFilter, setActiveDeptFilter] = useState<string>("ALL");
   const [activeStatusFilter, setActiveStatusFilter] = useState<string>("ALL"); 
-  
   const [expandedDepts, setExpandedDepts] = useState<string[]>([]);
 
-  const processedData = useMemo(() => {
-    // @Koi: I-filter nato daan ang data nga e-pass nimo gikan sa DB
-    // Siguroha lang nga tugma ang property names ani sa imong JSON response ha?
-    const filtered = (studentsData || []).filter(s => {
-      
-      const matchesSearch = 
-        (s.lname || "").toLowerCase().includes(searchQuery.toLowerCase()) || 
-        (s.fname || "").toLowerCase().includes(searchQuery.toLowerCase()) || 
-        (s.idNumber || "").includes(searchQuery);
+  // --- DATA STATES (For Lazy Loading) ---
+  // Stores the high-level count of students per department and course
+  const [summaryData, setSummaryData] = useState<any>({ groups: {}, sortedDepts: [], deptCounts: {}, totalResults: 0 });
+  
+  // Cache for storing paginated students fetched per course (e.g., { "BSIT-page-1": [...] })
+  const [courseStudentsCache, setCourseStudentsCache] = useState<Record<string, any[]>>({});
+  const [isLoadingSummary, setIsLoadingSummary] = useState(false);
 
-      const matchesDept = activeDeptFilter === "ALL" || s.department === activeDeptFilter;
-      const matchesStatus = activeStatusFilter === "ALL" || s.statusStep === parseInt(activeStatusFilter);
-
-      return matchesSearch && matchesDept && matchesStatus;
-    });
-
-    // Grouping logic nato aron ma-organize by Dept -> Program
-    const groups: Record<string, Record<string, any[]>> = {};
-    const deptCounts: Record<string, number> = {};
-
-    filtered.forEach(student => {
-      if (!groups[student.department]) {
-        groups[student.department] = {};
-        deptCounts[student.department] = 0;
-      }
-      if (!groups[student.department][student.program]) {
-        groups[student.department][student.program] = [];
-      }
-      groups[student.department][student.program].push(student);
-      deptCounts[student.department]++;
-    });
-
-    const sortedDepts = Object.keys(groups).sort((a, b) => {
-      const indexA = DEPARTMENT_ORDER.indexOf(a);
-      const indexB = DEPARTMENT_ORDER.indexOf(b);
-      return (indexA === -1 ? 999 : indexA) - (indexB === -1 ? 999 : indexB);
-    });
-
-    return { groups, sortedDepts, deptCounts, totalResults: filtered.length };
-  }, [searchQuery, activeDeptFilter, activeStatusFilter, studentsData]);
-
-  // @Koi: Na fix na nako ang infinite loop error diri
-  // Nag add kog stringify check aron di mag sige ug update ang state kung same ra ang gina search
+  // --- 1. DEBOUNCE SEARCH LOGIC ---
+  // Waits 500ms after the user stops typing before triggering backend requests
   useEffect(() => {
-    if (searchQuery.trim() !== "") {
-        const currentSorted = JSON.stringify(processedData.sortedDepts);
-        const currentExpanded = JSON.stringify(expandedDepts);
+    const handler = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+    }, 500);
+    return () => clearTimeout(handler);
+  }, [searchQuery]);
+
+  // --- 2. FETCH SUMMARY DATA ---
+  // Triggers whenever filters or search changes.
+  useEffect(() => {
+    const fetchSummary = async () => {
+      setIsLoadingSummary(true);
+      try {
+        /* TODO (@Koi): Replace this block with your actual GET endpoint for summary data.
+          Expected logic: Your backend should count how many students match the search/filters 
+          and return the grouped structure so the frontend can render the folders accurately.
+          
+          Example implementation:
+          const res = await fetch(`/api/masterlist/summary?search=${debouncedSearch}&dept=${activeDeptFilter}&status=${activeStatusFilter}`);
+          const data = await res.json();
+          setSummaryData(data);
+        */
         
-        if (currentSorted !== currentExpanded) {
-            setExpandedDepts(processedData.sortedDepts);
-        }
-    } else {
-        if (expandedDepts.length > 0) {
-            setExpandedDepts([]);
-        }
+        console.log("Fetching summary from DB with:", { debouncedSearch, activeDeptFilter, activeStatusFilter });
+        
+        // Mocking empty structure for now to prevent UI crashes
+        setSummaryData({ groups: {}, sortedDepts: [], deptCounts: {}, totalResults: 0 });
+
+      } catch (error) {
+        console.error("Failed to fetch summary data:", error);
+      } finally {
+        setIsLoadingSummary(false);
+      }
+    };
+
+    fetchSummary();
+  }, [debouncedSearch, activeDeptFilter, activeStatusFilter]);
+
+  // --- 3. FETCH PAGINATED STUDENTS PER COURSE ---
+  // Called by the UI only when a user opens a course folder or clicks next page
+  const fetchCourseStudents = async (courseName: string, page: number, limit: number = 9) => {
+    const cacheKey = `${courseName}-page-${page}`;
+    
+    // Return cached data if we already fetched this page
+    if (courseStudentsCache[cacheKey]) return;
+
+    try {
+      /* TODO (@Koi): Replace this with your paginated GET endpoint for specific students.
+        Expected logic: Return exactly 'limit' number of students for the given course & page.
+        
+        Example implementation:
+        const res = await fetch(`/api/masterlist/students?course=${courseName}&page=${page}&limit=${limit}&search=${debouncedSearch}&status=${activeStatusFilter}`);
+        const data = await res.json();
+        setCourseStudentsCache(prev => ({ ...prev, [cacheKey]: data.students }));
+      */
+      
+      console.log(`Fetching students -> Course: ${courseName} | Page: ${page} | Limit: ${limit}`);
+      
+    } catch (error) {
+      console.error(`Failed to fetch students for ${courseName}:`, error);
     }
-    // gi disable nako ang linter diri tuyo aron di mo reklamo inig build
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery]); 
+  };
 
   const toggleDept = (dept: string) => {
-    setExpandedDepts(prev => 
-      prev.includes(dept) ? prev.filter(d => d !== dept) : [...prev, dept]
-    );
+    setExpandedDepts(prev => prev.includes(dept) ? prev.filter(d => d !== dept) : [...prev, dept]);
   };
 
   return {
+    // States & Handlers
     searchQuery, setSearchQuery,
     selectedStudent, setSelectedStudent,
     activeDeptFilter, setActiveDeptFilter,
     activeStatusFilter, setActiveStatusFilter,
     expandedDepts, toggleDept,
-    processedData, DEPARTMENT_ORDER, STATUS_STEPS
+    
+    // Data & Fetching Functions
+    summaryData, 
+    isLoadingSummary,
+    courseStudentsCache, 
+    fetchCourseStudents,
+    
+    // Constants
+    DEPARTMENT_ORDER, STATUS_STEPS
   };
 }


### PR DESCRIPTION
## Description
This PR refactors the `MasterlistTab` and `useMasterlist` hook to shift from client-side data processing (which causes heavy UI lag with thousands of records) to a scalable **Server-Side Pagination & Lazy Loading** architecture.

## Architectural Changes (`useMasterlist.ts`)
* **Removed Heavy Props:** The hook no longer accepts the massive `studentsData` array.
* **Debounced Search:** Implemented a 500ms debounce on the search query to prevent spamming the backend while the admin is typing.
* **Two-Step Fetching Strategy:**
  1. `summaryData`: Initial load now only requires a lightweight grouping of student counts per department and course to render the UI folders.
  2. `courseStudentsCache`: Created a caching system and dynamic fetch function (`fetchCourseStudents`) to only request specific students (Limit: 9) when a course folder is opened or a page is changed.
* **Note:** Added `// TODO (@Koi)` placeholders inside the hook where the actual API fetch requests should be integrated.

## UI Updates (`MasterlistTab.tsx`)
* Removed the `studentsData` prop dependency.
* Integrated a loading state (`Loader2`) to improve UX while fetching the database summary.
* Rewired the folder click and pagination buttons to trigger the specific paginated backend requests instead of manipulating a local array.

## Notes for Backend (@Koi)
The frontend is now 100% API-ready. It is expecting two endpoints to be plugged into the `useMasterlist` hook:
1. An endpoint returning the summary/counts for the folders.
2. A paginated endpoint returning exactly 9 students per requested course/page.