### PR TITLE
feat(dashboard): enhance schedule booking and format yearbook preview names

### DIFF
--- a/src/components/student/dashboard/BookingWidget.tsx
+++ b/src/components/student/dashboard/BookingWidget.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState } from "react";
-// BAG-O: Gi-add nato ang Loader2 para sa loading spinner
-import { Calendar, CheckCircle, AlertTriangle, Loader2 } from "lucide-react"; 
+import { Calendar, CheckCircle, AlertTriangle, Loader2, Edit } from "lucide-react"; 
 import QRCode from "react-qr-code"; 
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -14,7 +13,6 @@ interface BookingWidgetProps {
   bookingList: Schedule[], 
   booking?: Booking,
   idNumber: string;
-  // BAG-O: Gi-change nato to Promise<void> aron maka-await ta sa API call
   onBook: (booking_id: number, period: string) => Promise<void> | void;
 };
 
@@ -24,8 +22,6 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
   const [selectedBookingId, setSelectedBookingId] = useState<number>(0);
   const [selectedDate, setSelectedDate] = useState("");
   const [selectedSession, setSelectedSession] = useState<"AM" | "PM" | "">("");
-  
-  // BAG-O: State para ma-lock ang button inig submit
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSelectSlot = (booking_id: number, date: string, session: "AM" | "PM", isFull: boolean) => {
@@ -35,21 +31,27 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
     setSelectedSession(session);
   };
 
-  // BAG-O: Gihimo natong async para mag-huwat sa API ni Koi
   const handleConfirm = async () => {
     if (selectedDate && selectedSession) {
-        setIsSubmitting(true); // I-lock ang button!
+        setIsSubmitting(true);
         try {
             await onBook(selectedBookingId, selectedSession);
-            // Inig human og save, diha pa nato isira ang dialogs
             setIsConfirmDialogOpen(false);
             setIsBookingModalOpen(false);
         } catch (error) {
             console.error("Booking failed:", error);
         } finally {
-            setIsSubmitting(false); // I-unlock ang button (in case nag error)
+            setIsSubmitting(false);
         }
     }
+  };
+
+  // Helper to open modal for re-booking
+  const handleRebookClick = () => {
+    setSelectedBookingId(0);
+    setSelectedDate("");
+    setSelectedSession("");
+    setIsBookingModalOpen(true);
   };
 
   return (
@@ -70,8 +72,8 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
           <div className="w-full bg-stone-50 border border-stone-200 rounded-xl p-6 flex flex-col md:flex-row justify-between items-center gap-6 relative overflow-hidden">
             <div className="absolute top-0 left-0 w-2 h-full bg-green-500"></div>
             
-            <div className="space-y-1 flex-1">
-              <div className="flex items-center gap-2">
+            <div className="space-y-1 flex-1 w-full text-center md:text-left">
+              <div className="flex items-center justify-center md:justify-start gap-2">
                 <Badge className="bg-green-600 hover:bg-green-600">CONFIRMED</Badge>
                 <p className="text-xs font-bold text-stone-400 uppercase tracking-wider">Pictorial Pass</p>
               </div>
@@ -81,10 +83,17 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
               <p className="text-stone-600 font-medium">
                 {booking.period === 'AM' ? '☀️ Morning Session (8AM - 12PM)' : '🌙 Afternoon Session (1PM - 5PM)'}
               </p>
-              <p className="text-xs text-stone-400 italic mt-2">Present this QR to the attendance officer.</p>
+              <p className="text-xs text-stone-400 italic mt-2 mb-4 md:mb-0">Present this QR to the attendance officer.</p>
+              
+              {/* CHANGE SCHEDULE BUTTON */}
+              <div className="pt-2">
+                  <Button variant="outline" size="sm" onClick={handleRebookClick} className="text-amber-700 border-amber-300 hover:bg-amber-50">
+                      <Edit className="w-3.5 h-3.5 mr-2" /> Change Schedule
+                  </Button>
+              </div>
             </div>
 
-            <div className="flex flex-col items-center gap-2 bg-white p-4 rounded-lg border border-stone-200 shadow-sm">
+            <div className="flex flex-col items-center gap-2 bg-white p-4 rounded-lg border border-stone-200 shadow-sm shrink-0">
               <div style={{ height: "auto", margin: "0 auto", maxWidth: 100, width: "100%" }}>
                 <QRCode
                   size={256}
@@ -97,7 +106,7 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
             </div>
           </div>
         ) : (
-          // --- BOOKING UI ---
+          // --- INITIAL BOOKING UI ---
           <div className="text-center space-y-4 py-6">
              <div className="w-16 h-16 bg-amber-50 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Calendar className="w-8 h-8 text-amber-600" />
@@ -107,91 +116,91 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
                  <p className="text-sm text-stone-500 max-w-xs mx-auto">Slots are filling up fast. Book now to secure your spot.</p>
              </div>
              
-             <Dialog open={isBookingModalOpen} onOpenChange={setIsBookingModalOpen}>
-                <DialogTrigger asChild>
-                    <Button className="bg-amber-900 hover:bg-amber-800">Book a Slot Now</Button>
-                </DialogTrigger>
-                <DialogContent className="max-w-2xl">
-                    <DialogHeader>
-                        <DialogTitle>Select Pictorial Schedule</DialogTitle>
-                        <DialogDescription>Choose a session. Capacity is limited.</DialogDescription>
-                    </DialogHeader>
-                    
-                    <div className="py-4 space-y-4 max-h-[60vh] overflow-y-auto pr-2">
-                        {bookingList.map((slot, idx) => (
-                            <div key={idx} className="border rounded-lg p-4 space-y-3 bg-stone-50/50">
-                                <h4 className="font-bold text-stone-700">
-                                  {new Date(slot.date).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
-                                </h4>
-                                <div className="grid grid-cols-2 gap-4">
-                                    {['AM', 'PM'].map((sessionType) => {
-                                        const isAM = sessionType === 'AM';
-                                        const booked = isAM ? slot.curr_morning : slot.curr_afternoon;
-                                        const capacity = isAM ? slot.max_morning_cap : slot.max_afternoon_cap;
-                                        const isFull = booked >= capacity;
-                                        
-                                        return (
-                                            <button 
-                                                key={sessionType}
-                                                onClick={() => handleSelectSlot(
-                                                  slot.id,
-                                                  slot.date, 
-                                                  sessionType as "AM"|"PM",
-                                                  isFull
-                                                )}
-                                                disabled={isFull}
-                                                className={`relative border rounded-lg p-3 text-left transition-all ${selectedDate === slot.date && selectedSession === sessionType ? 'ring-2 ring-amber-600 border-amber-600 bg-amber-50' : 'hover:border-amber-300 bg-white'} ${isFull ? 'opacity-50 cursor-not-allowed bg-stone-100' : ''}`}
-                                            >
-                                                <div className="flex justify-between items-center mb-2">
-                                                    <span className="font-bold text-sm text-stone-700">{isAM ? 'Morning (AM)' : 'Afternoon (PM)'}</span>
-                                                    {selectedDate === slot.date && selectedSession === sessionType && <CheckCircle className="w-4 h-4 text-amber-600"/>}
-                                                </div>
-                                                <div className="h-1.5 w-full bg-stone-200 rounded-full overflow-hidden">
-                                                    <div className={`h-full ${isFull ? 'bg-red-500' : 'bg-amber-500'}`} style={{ width: `${(booked / capacity) * 100}%` }} />
-                                                </div>
-                                                <span className="text-[10px] text-stone-500 mt-1 block">{booked}/{capacity} Taken</span>
-                                            </button>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-
-                    <DialogFooter className="flex-col sm:justify-between gap-2 border-t pt-4">
-                        <div className="text-xs text-stone-500 text-center sm:text-left">
-                            {selectedDate ? <span>Selected: <strong>{new Date(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })} ({selectedSession})</strong></span> : "Please select a slot"}
-                        </div>
-                        <Button onClick={() => setIsConfirmDialogOpen(true)} disabled={!selectedDate || !selectedSession} className="bg-amber-900 w-full sm:w-auto">Submit Schedule</Button>
-                    </DialogFooter>
-                </DialogContent>
-             </Dialog>
-
-             <Dialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
-                <DialogContent className="max-w-md">
-                    <DialogHeader>
-                        <DialogTitle className="flex items-center gap-2 text-red-600"><AlertTriangle className="w-5 h-5" /> Final Confirmation</DialogTitle>
-                        <DialogDescription className="pt-2">
-                          You are about to book: <br/>
-                            <span className="font-bold text-stone-800 block mt-1 text-lg">
-                              {new Date(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })} • {selectedSession}
-                            </span>
-                        </DialogDescription>
-                    </DialogHeader>
-                    <DialogFooter>
-                        {/* BAG-O: I-disable ang Cancel button kung nag submit na */}
-                        <Button variant="outline" onClick={() => setIsConfirmDialogOpen(false)} disabled={isSubmitting}>Cancel</Button>
-                        
-                        {/* BAG-O: Ang Confirm button naay loading state, gi-disable inig click, ug naay spinner */}
-                        <Button onClick={handleConfirm} disabled={isSubmitting} className="bg-red-600 hover:bg-red-700 text-white flex items-center gap-2">
-                            {isSubmitting && <Loader2 className="w-4 h-4 animate-spin" />}
-                            {isSubmitting ? "Booking..." : "Yes, Finalize"}
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-             </Dialog>
+             <Button className="bg-amber-900 hover:bg-amber-800" onClick={() => setIsBookingModalOpen(true)}>Book a Slot Now</Button>
           </div>
         )}
+
+        {/* MODALS MOVED OUTSIDE CONDITIONAL RENDER TO RE-USE THEM */}
+        <Dialog open={isBookingModalOpen} onOpenChange={setIsBookingModalOpen}>
+            <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>{booking ? "Change Schedule" : "Select Pictorial Schedule"}</DialogTitle>
+                    <DialogDescription>Choose an available session. Capacity is limited.</DialogDescription>
+                </DialogHeader>
+                
+                <div className="py-4 space-y-4 max-h-[60vh] overflow-y-auto pr-2">
+                    {bookingList.map((slot, idx) => (
+                        <div key={idx} className="border rounded-lg p-4 space-y-3 bg-stone-50/50">
+                            <h4 className="font-bold text-stone-700">
+                              {new Date(slot.date).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}
+                            </h4>
+                            <div className="grid grid-cols-2 gap-4">
+                                {['AM', 'PM'].map((sessionType) => {
+                                    const isAM = sessionType === 'AM';
+                                    const booked = isAM ? slot.curr_morning : slot.curr_afternoon;
+                                    const capacity = isAM ? slot.max_morning_cap : slot.max_afternoon_cap;
+                                    const isFull = booked >= capacity;
+                                    
+                                    return (
+                                        <button 
+                                            key={sessionType}
+                                            onClick={() => handleSelectSlot(
+                                              slot.id,
+                                              slot.date, 
+                                              sessionType as "AM"|"PM",
+                                              isFull
+                                            )}
+                                            disabled={isFull}
+                                            className={`relative border rounded-lg p-3 text-left transition-all ${selectedDate === slot.date && selectedSession === sessionType ? 'ring-2 ring-amber-600 border-amber-600 bg-amber-50' : 'hover:border-amber-300 bg-white'} ${isFull ? 'opacity-50 cursor-not-allowed bg-stone-100' : ''}`}
+                                        >
+                                            <div className="flex justify-between items-center mb-2">
+                                                <span className="font-bold text-sm text-stone-700">{isAM ? 'Morning (AM)' : 'Afternoon (PM)'}</span>
+                                                {selectedDate === slot.date && selectedSession === sessionType && <CheckCircle className="w-4 h-4 text-amber-600"/>}
+                                            </div>
+                                            <div className="h-1.5 w-full bg-stone-200 rounded-full overflow-hidden">
+                                                <div className={`h-full ${isFull ? 'bg-red-500' : 'bg-amber-500'}`} style={{ width: `${(booked / capacity) * 100}%` }} />
+                                            </div>
+                                            <span className="text-[10px] text-stone-500 mt-1 block">{booked}/{capacity} Taken</span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                <DialogFooter className="flex-col sm:justify-between gap-2 border-t pt-4">
+                    <div className="text-xs text-stone-500 text-center sm:text-left">
+                        {selectedDate ? <span>Selected: <strong>{new Date(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })} ({selectedSession})</strong></span> : "Please select a slot"}
+                    </div>
+                    <Button onClick={() => setIsConfirmDialogOpen(true)} disabled={!selectedDate || !selectedSession} className="bg-amber-900 w-full sm:w-auto">
+                        {booking ? "Confirm New Schedule" : "Submit Schedule"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+         </Dialog>
+
+         <Dialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2 text-red-600"><AlertTriangle className="w-5 h-5" /> Final Confirmation</DialogTitle>
+                    <DialogDescription className="pt-2">
+                      {booking ? "You are about to re-book and override your previous schedule with:" : "You are about to book:"} <br/>
+                        <span className="font-bold text-stone-800 block mt-1 text-lg">
+                          {new Date(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })} • {selectedSession}
+                        </span>
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => setIsConfirmDialogOpen(false)} disabled={isSubmitting}>Cancel</Button>
+                    <Button onClick={handleConfirm} disabled={isSubmitting} className="bg-red-600 hover:bg-red-700 text-white flex items-center gap-2">
+                        {isSubmitting && <Loader2 className="w-4 h-4 animate-spin" />}
+                        {isSubmitting ? "Booking..." : "Yes, Finalize"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+         </Dialog>
+
       </CardContent>
     </Card>
   );

--- a/src/components/student/dashboard/YearbookPreview.tsx
+++ b/src/components/student/dashboard/YearbookPreview.tsx
@@ -13,17 +13,36 @@ interface YearbookPreviewProps {
 export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
   const stud_detail = user.studentDetail;
 
-  // HELPER FUNCTION: Safely combines the title (Mr/Mrs/Dr) with the name.
-  // It also prevents double titles just in case the student typed "Mr. John" in the name field.
+  const formatParentNameAsInitial = (nameStr?: string) => {
+    if (!nameStr || nameStr.trim() === "" || nameStr === "N/A") return "N/A";
+    
+    // Split the full name by space
+    const parts = nameStr.trim().split(/\s+/);
+    if (parts.length <= 2) return nameStr; 
+
+    // Extract First, Middle (as initial), and Last
+    const firstName = parts[0];
+    const lastName = parts[parts.length - 1];
+    
+    // Collect all middle parts and get the first letter of the first middle word
+    const middleParts = parts.slice(1, parts.length - 1);
+    const middleInitial = middleParts[0].charAt(0).toUpperCase() + ".";
+
+    return `${firstName} ${middleInitial} ${lastName}`;
+  };
+
+  // Safely combines the title (Mr/Mrs/Dr) with the formatted name.
   const formatNameWithTitle = (name?: string, title?: string, defaultTitle?: string) => {
-    if (!name || name.trim() === "") return null;
+    const formattedName = formatParentNameAsInitial(name);
+    if (!formattedName || formattedName === "N/A") return "N/A";
+    
     const finalTitle = title || defaultTitle || "";
     
     // Check if the name already starts with the title to avoid "Mr. Mr. John"
-    if (finalTitle && !name.toLowerCase().startsWith(finalTitle.toLowerCase().replace(".", ""))) {
-      return `${finalTitle} ${name}`;
+    if (finalTitle && !formattedName.toLowerCase().startsWith(finalTitle.toLowerCase().replace(".", ""))) {
+      return `${finalTitle} ${formattedName}`;
     }
-    return name;
+    return formattedName;
   };
 
   const guardian = stud_detail?.guardians_name && stud_detail.guardians_name.trim() !== "" 
@@ -33,9 +52,9 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
   const details = {
     personal: {
       fname: user?.first_name,
-      mname: user?.mid_name,
+      mname: user?.mid_name, 
       lname: user?.last_name,
-      suffix: user?.suffix,
+      suffix: user?.suffix, 
       nickname: user?.nickname, 
       birthdate: new Date(stud_detail.birth_date).toLocaleDateString('en-US', { 
         month: 'long', 
@@ -67,7 +86,7 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto min-h-screen bg-[#2a1a10] text-amber-50 font-sans selection:bg-amber-500/30">
       
-      {/* FLOATING BACK BUTTON - UPDATED CONTRAST */}
+      {/* FLOATING BACK BUTTON */}
       <div className="fixed top-4 left-4 z-50">
         <Button 
           onClick={onClose}
@@ -83,14 +102,11 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
       </div>
 
       {/* --- MAIN CONTENT CONTAINER --- */}
-      {/* Desktop: Grid with 2 Columns (40% / 60%). Mobile: Flex Column */}
       <div className="w-full min-h-screen lg:h-screen flex flex-col lg:flex-row">
         
-        {/* --- LEFT: PHOTO SECTION (40% width on Desktop) --- */}
+        {/* --- LEFT: PHOTO SECTION --- */}
         <div className="w-full lg:w-[40%] bg-stone-100 relative flex items-center justify-center p-8 lg:p-12 order-1 pt-24 lg:pt-12">
-            {/* White Frame Effect */}
             <div className="bg-white p-4 shadow-2xl rotate-1 w-full max-w-md mx-auto relative z-10">
-                {/* Image Container with fixed aspect ratio */}
                 <div className="aspect-[3/4] w-full bg-stone-200 relative overflow-hidden">
                    <img 
                      src={photoUrl} 
@@ -98,19 +114,15 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
                      className="w-full h-full object-cover" 
                    />
                 </div>
-                {/* Name Tag on Photo */}
                 <div className="absolute -bottom-6 left-1/2 -translate-x-1/2 bg-[#2a1a10] text-white px-6 py-2 shadow-lg w-max max-w-[90%] text-center">
                    <span className="text-xl font-serif font-bold tracking-widest truncate block">{details.personal.lname}</span>
                 </div>
             </div>
-
-            {/* Pattern Overlay on Left Side */}
             <div className="absolute inset-0 bg-[url('https://www.transparenttextures.com/patterns/cubes.png')] opacity-5 pointer-events-none mix-blend-multiply"></div>
         </div>
 
-        {/* --- RIGHT: DETAILS SECTION (60% width on Desktop) --- */}
+        {/* --- RIGHT: DETAILS SECTION --- */}
         <div className="w-full lg:w-[60%] bg-[#3f2e22] relative flex flex-col justify-center p-8 md:p-16 lg:p-20 order-2 pt-16 lg:pt-8">
-            {/* Texture */}
             <div className="absolute inset-0 opacity-10 pointer-events-none" style={{ backgroundImage: "url('https://www.transparenttextures.com/patterns/leather.png')" }}></div>
 
             <div className="relative z-10 max-w-3xl mx-auto w-full">
@@ -122,7 +134,12 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
                    </h1>
                    <div className="flex flex-wrap items-baseline gap-3 text-2xl md:text-4xl text-amber-100/80 font-serif">
                      <span>{details.personal.fname}</span>
-                     <span>{details.personal.mname ? details.personal.mname.charAt(0) + "." : ""}</span>
+                     <span>{details.personal.mname ? details.personal.mname : ""}</span>
+                     
+                     {details.personal.suffix && details.personal.suffix !== "N/A" && (
+                         <span>{details.personal.suffix}</span>
+                     )}
+
                      <span className="italic text-amber-500">"{details.personal.nickname}"</span>
                    </div>
                    <div className="mt-6 flex items-center gap-3">
@@ -139,7 +156,6 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
                 {/* CONTENT GRID */}
                 <div className="flex flex-col md:flex-row gap-10">
                     
-                    {/* THEME PHOTO BOX (Placeholder) */}
                     <div className="hidden md:block w-48 shrink-0">
                        <div className="aspect-[3/4] bg-white/5 border border-white/10 p-2 relative group cursor-not-allowed">
                           <div className="w-full h-full bg-[#2a1a10] flex flex-col items-center justify-center text-center p-4">
@@ -149,7 +165,6 @@ export function YearbookPreview({ user, onClose }: YearbookPreviewProps) {
                        </div>
                     </div>
 
-                    {/* DETAILS TEXT */}
                     <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-8 text-sm font-light text-amber-100/80">
                        
                        <div className="space-y-6">


### PR DESCRIPTION
This PR addresses UI/UX improvements in the Student Dashboard, specifically enhancing the Booking Widget and correcting the name formatting in the Yearbook Draft Preview.

## Key Changes & Fixes
* **Schedule Re-booking:** Added a "Change Schedule" button in the `BookingWidget` for users who have already booked. They can now re-open the booking modal and select a new schedule (as long as the target slot is not full). Added `isSubmitting` loading states to prevent double-clicking during API calls.
* **Student Name Formatting:** Fixed the `YearbookPreview` to ensure the student's Middle Name is spelled out completely, and the Suffix (e.g., Jr., Sr.) is properly displayed next to their name.
* **Parent/Guardian Name Formatting:** Added a new helper function `formatParentNameAsInitial` in the `YearbookPreview`. This automatically detects the middle name of parents/guardians and converts it into a middle initial (e.g., "Juan Gomez Cruz" -> "Juan G. Cruz").

*(Note: The Solicitation Widget is excluded from this preview as it was hidden in PR #76).*