### PR TITLE
fix(admin): map UM Student Email to correct database field

### DIFF
--- a/src/components/admin/tabs/VerificationTab.tsx
+++ b/src/components/admin/tabs/VerificationTab.tsx
@@ -260,9 +260,18 @@ export function VerificationTab({ pendingStudents, currentPage, totalUnverified,
                                     </h3>
                                     <div className="space-y-5">
                                         <div>
-                                            <span className="text-xs font-bold text-stone-400 uppercase tracking-wider block mb-1">Email Address</span>
+                                            <span className="text-xs font-bold text-stone-400 uppercase tracking-wider block mb-1">Personal Email Address</span>
                                             <p className="text-base font-medium text-stone-800">{cleanText(selectedStudent.personal_email) || "N/A"}</p>
                                         </div>
+
+                                        {/* Renders UM Student Email conditionally if the value exists */}
+                                        {cleanText(selectedStudent?.school_email) && (
+                                            <div>
+                                                <span className="text-xs font-bold text-stone-400 uppercase tracking-wider block mb-1">UM Student Email</span>
+                                                <p className="text-base font-medium text-stone-800">{cleanText(selectedStudent?.school_email)}</p>
+                                            </div>
+                                        )}
+
                                         <div>
                                             <span className="text-xs font-bold text-stone-400 uppercase tracking-wider block mb-1">Birthdate</span>
                                             <p className="text-base font-medium text-stone-800">


### PR DESCRIPTION
This PR updates the Admin Verification UI to include the student's official university email, as requested. This provides admins with more complete student information during the verification process.

## Key Changes
* **Added School Email Display:** Updated the `VerificationTab.tsx` to render the student's official UM email under the Personal Details section.
* **Conditional Rendering:** The field dynamically hides itself to keep the UI clean if the student did not provide a school email during pre-registration.