### PR TITLE
chore: close registration path and buttons for now

### DIFF
--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,10 +1,15 @@
 import RegistrationWizard from "@/components/forms/RegistrationWizard";
+import { redirect } from "next/navigation";
 
 export default function RegisterPage() {
+  /* closed for now
   return (
     // Keeping your exact layout so the Wizard takes full screen
     <main className="w-full min-h-screen bg-stone-50">
       <RegistrationWizard />
     </main>
   );
+  */
+
+  redirect('/');
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,11 +206,15 @@ export default function AuriumLandingPage() {
                 <span className="hidden sm:inline">Portal Login</span>
               </Button>
             </Link>
+
+            {/* TODO: closed
             <Link href="/auth/register">
               <Button className="bg-amber-900 hover:bg-amber-800 text-white shadow-lg shadow-amber-900/20 rounded-full px-6 transition-all hover:scale-105">
                 Pre-Register
               </Button>
             </Link>
+            */}
+
           </div>
 
           {/* Placeholder to balance the flex layout on mobile (invisible) */}
@@ -289,11 +293,14 @@ export default function AuriumLandingPage() {
             </motion.p>
             
             <motion.div variants={fadeInUp} className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+
+              {/* TODO: closed
               <Link href="/auth/register" className="w-full sm:w-auto">
                 <Button size="lg" className="w-full sm:w-auto bg-amber-900 hover:bg-amber-800 text-white px-8 md:px-10 h-14 md:h-16 text-lg rounded-full shadow-xl shadow-amber-900/20 transition-transform hover:-translate-y-1 font-bold">
                   Start Registration
                 </Button>
               </Link>
+              */}
               
               <div className="w-full sm:w-auto">
                 <Link href="#editions" className="block w-full">


### PR DESCRIPTION
This pull request temporarily disables user registration in the application. The registration page now redirects users to the homepage, and all registration-related buttons and links are commented out on the landing page to prevent access.

**Registration flow changes:**

* The `RegisterPage` now immediately redirects users to the homepage instead of rendering the registration wizard.

**Landing page UI updates:**

* All "Pre-Register" and "Start Registration" buttons and links are commented out on the landing page, removing visible registration options from the UI.