### PR TITLE
chore: refc to new routes

### DIFF
--- a/src/app/admin/adminService.tsx
+++ b/src/app/admin/adminService.tsx
@@ -209,7 +209,7 @@ export async function overrideStudentScheduleByNumber(studentNumber: string | nu
 
 export const fv_getPaginatedStudents = async (page: number) => {
     try {
-        const res = await fetch(`${baseUrl}/api/admin/finalize/fetch?page=${page}`, {
+        const res = await fetch(`${baseUrl}/api/admin/finalize?page=${page}`, {
              credentials: 'include' 
         });
 
@@ -226,7 +226,7 @@ export const fv_getPaginatedStudents = async (page: number) => {
 
 export async function fv_updateStudent(studentId: number, type: string, data: any) {
     try {
-        const res = await fetch(`${baseUrl}/api/admin/finalize/update/${studentId}?type=${type}`, {
+        const res = await fetch(`${baseUrl}/api/admin/finalize/${studentId}?type=${type}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(data),
@@ -247,7 +247,7 @@ export async function fv_updateStudent(studentId: number, type: string, data: an
 
 export async function fv_finalizeStudent(studentId: string | number) {
     try {
-        const res = await fetch(`${baseUrl}/api/admin/finalize/verify?id=${encodeURIComponent(String(studentId))}`, {
+        const res = await fetch(`${baseUrl}/api/admin/finalize?id=${encodeURIComponent(String(studentId))}`, {
             method: "PATCH",
             credentials: 'include'
         });


### PR DESCRIPTION
This pull request updates several API endpoint URLs in the `src/app/admin/adminService.tsx` file to align with backend route changes and improve consistency. The main focus is on simplifying and standardizing the endpoints used for student-related admin actions.

**API endpoint updates:**

* Updated the fetch URL in `fv_getPaginatedStudents` to remove the `/fetch` subroute, now using `/api/admin/finalize?page=...` for paginated student retrieval.
* Changed the update URL in `fv_updateStudent` to remove the `/update` subroute, now using `/api/admin/finalize/${studentId}?type=...` for student updates.
* Modified the finalize URL in `fv_finalizeStudent` to remove the `/verify` subroute, now using `/api/admin/finalize?id=...` for finalizing a student.