### PR TITLE
feat: delete entire student record through masterlist tab

### DIFF
--- a/src/app/admin/adminService.tsx
+++ b/src/app/admin/adminService.tsx
@@ -81,6 +81,19 @@ export async function handleCancel(studentId: number) {
     }
 }
 
+export async function handleDelete(studentId: number) {
+    try {
+        const res = await fetch(`${baseUrl}/api/admin/student/${studentId}`, {
+            method: "DELETE",
+            credentials: 'include'
+        });
+        return !res.ok ? false : true;
+    } catch (err) {
+        console.error(err);
+        return false;
+    }
+}
+
 export async function addSchedule(date: string, am_cap: number, pm_cap: number) {
     const body = { 
         date: date, 

--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useMasterlist } from "@/hooks/useMasterlist";
+import * as adminService from "@/app/admin/adminService";
 
 type MasterlistTabProps = ReturnType<typeof useMasterlist>;
 const baseUrl = process.env.NEXT_PUBLIC_LOCAL_URL || "";
@@ -69,20 +70,17 @@ export function MasterlistTab(props: MasterlistTabProps) {
 
   const handleDeleteRecord = async () => {
       if (!selectedStudent) return;
-      
+       
       setIsDeleting(true);
       try {
-          const res = await fetch(`/api/student/${selectedStudent.id}`, {
-              method: 'DELETE',
-          });
+        const res = adminService.handleDelete(selectedStudent.student_number);
+        if (!res) throw new Error("Failed to delete record");
 
-          if (!res.ok) throw new Error("Failed to delete record");
-
-          toast.success("Student record has been successfully deleted.");
-          setShowDeleteConfirm(false);
-          setSelectedStudent(null);
+        toast.success("Student record has been successfully deleted.");
+        setShowDeleteConfirm(false);
+        setSelectedStudent(null);
           
-          handleLoadClick();
+        handleLoadClick();
       } catch (error) {
           console.error("Deletion error:", error);
           toast.error("Unable to delete the record at this time. Please try again.");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
This pull request introduces a new function to handle student record deletion in the admin service and updates the masterlist tab to use this new function, improving code organization and error handling. The key changes are grouped below:

**Admin service enhancements:**

* Added a new `handleDelete` function to `adminService.tsx` that deletes a student record by sending a `DELETE` request to the backend API and handles errors gracefully.

**Masterlist tab refactor:**

* Updated `MasterlistTab.tsx` to import the new `handleDelete` function from `adminService` and use it when deleting a student, replacing the previous inline fetch logic. This centralizes API logic and improves maintainability.