### PR TITLE
feat: secure data export with special picker and inclusions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-pageflip": "^2.0.3",
         "react-qr-code": "^2.0.18",
         "tailwind-merge": "^3.4.0",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.5"
       },
       "devDependencies": {
@@ -5670,6 +5671,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -6157,6 +6167,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6230,6 +6253,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6282,6 +6314,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-spawn": {
@@ -7407,6 +7451,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/framer-motion": {
@@ -10375,6 +10428,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -11162,6 +11227,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -11191,6 +11274,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-pageflip": "^2.0.3",
     "react-qr-code": "^2.0.18",
     "tailwind-merge": "^3.4.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -2,17 +2,60 @@
 
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { Search, BookOpen, GraduationCap, FileText, MapPin, Phone, Mail, Clock, Filter, User, Image as ImageIcon, X, Home, Building2, ListFilter, ChevronLeft, ChevronRight, Loader2, Download, Trash2, AlertTriangle, Send, CheckCircle2 } from "lucide-react";
+import { Search, BookOpen, GraduationCap, FileText, MapPin, Phone, Mail, Clock, Filter, User, Image as ImageIcon, X, Home, Building2, ListFilter, ChevronLeft, ChevronRight, Loader2, Download, Trash2, AlertTriangle, Send, CheckCircle2, FileSpreadsheet } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import * as XLSX from "xlsx";
 import { useMasterlist } from "@/hooks/useMasterlist";
 import * as adminService from "@/app/admin/adminService";
 
 type MasterlistTabProps = ReturnType<typeof useMasterlist>;
 const baseUrl = process.env.NEXT_PUBLIC_LOCAL_URL || "";
+
+const EXPORT_COLUMN_GROUPS = [
+  { label: "Academic", columns: [
+    { key: "student_number", label: "Student No." },
+    { key: "department",     label: "Department" },
+    { key: "course",         label: "Course" },
+    { key: "major",          label: "Major" },
+    { key: "thesis_title",   label: "Thesis Title" },
+    { key: "status",         label: "Status" },
+    { key: "created_at",     label: "Date Registered" },
+  ]},
+  { label: "Personal", columns: [
+    { key: "last_name",  label: "Last Name" },
+    { key: "first_name", label: "First Name" },
+    { key: "mid_name",   label: "Middle Name" },
+    { key: "nickname",   label: "Nickname" },
+    { key: "suffix",     label: "Suffix" },
+    { key: "birth_date", label: "Birth Date" },
+  ]},
+  { label: "Contact", columns: [
+    { key: "personal_email", label: "Personal Email" },
+    { key: "school_email",   label: "School Email" },
+    { key: "contact_num",    label: "Contact No." },
+  ]},
+  { label: "Address", columns: [
+    { key: "province", label: "Province" },
+    { key: "city",     label: "City" },
+    { key: "barangay", label: "Barangay" },
+  ]},
+  { label: "Family", columns: [
+    { key: "mothers_name",    label: "Mother's Name" },
+    { key: "mothers_title",   label: "Mother's Title" },
+    { key: "fathers_name",    label: "Father's Name" },
+    { key: "fathers_title",   label: "Father's Title" },
+    { key: "guardians_name",  label: "Guardian's Name" },
+    { key: "guardians_title", label: "Guardian's Title" },
+  ]},
+];
+
+const DEFAULT_EXPORT_COLUMNS = new Set(["student_number", "first_name", "last_name", "department", "course", "major", "status"]);
 
 export function MasterlistTab(props: MasterlistTabProps) {
   const {
@@ -41,6 +84,11 @@ export function MasterlistTab(props: MasterlistTabProps) {
   // UX update: New states for the OTP Confirmation workflow
   const [otpConfirmTarget, setOtpConfirmTarget] = useState<'personal' | 'school' | null>(null);
   const [isResendingOtp, setIsResendingOtp] = useState(false);
+
+  // Export States
+  const [showExportDialog, setShowExportDialog] = useState(false);
+  const [selectedColumns, setSelectedColumns] = useState<Set<string>>(new Set(DEFAULT_EXPORT_COLUMNS));
+  const [isExporting, setIsExporting] = useState(false);
 
   const getObjectKey = (url: string): string => {
     if (typeof url !== 'string') return "";
@@ -169,6 +217,59 @@ export function MasterlistTab(props: MasterlistTabProps) {
       }
   };
 
+  const toggleColumn = (key: string) => {
+    setSelectedColumns(prev => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  const toggleGroup = (keys: readonly { key: string }[]) => {
+    const allSelected = keys.every(c => selectedColumns.has(c.key));
+    setSelectedColumns(prev => {
+      const next = new Set(prev);
+      keys.forEach(c => allSelected ? next.delete(c.key) : next.add(c.key));
+      return next;
+    });
+  };
+
+  const handleExport = async () => {
+    if (selectedColumns.size === 0) {
+      toast.error("Please select at least one column to export.");
+      return;
+    }
+    setIsExporting(true);
+    try {
+      const query = new URLSearchParams({
+        columns: Array.from(selectedColumns).join(","),
+        dept: activeDeptFilter || "ALL",
+        course: activeCourseFilter || "ALL",
+        major: activeMajorFilter || "ALL",
+        status: activeStatusFilter || "ALL",
+      });
+      const res = await fetch(`${baseUrl}/api/admin/masterlist/export?${query}`, { credentials: "include" });
+      if (!res.ok) throw new Error("Export failed");
+      const { data, total } = await res.json();
+      const keyToLabel = Object.fromEntries(
+        EXPORT_COLUMN_GROUPS.flatMap(g => g.columns.map(c => [c.key, c.label]))
+      );
+      const labeled = (data as Record<string, any>[]).map(row =>
+        Object.fromEntries(Object.entries(row).map(([k, v]) => [keyToLabel[k] ?? k, v]))
+      );
+      const ws = XLSX.utils.json_to_sheet(labeled);
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, "Masterlist");
+      XLSX.writeFile(wb, `masterlist_${new Date().toISOString().split("T")[0]}.xlsx`);
+      toast.success(`Exported ${total} records successfully.`);
+      setShowExportDialog(false);
+    } catch {
+      toast.error("Export failed. Please try again.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
   const InfoField = ({ label, value, icon: Icon, fullWidth = false }: any) => (
     <div className={`flex flex-col space-y-1 ${fullWidth ? "col-span-2" : "col-span-1"}`}>
         <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider flex items-center gap-1.5">
@@ -200,9 +301,20 @@ export function MasterlistTab(props: MasterlistTabProps) {
                         Secure repository of verified graduates. Monitoring all students from Registration to Final Verification.
                     </p>
                 </div>
-                <Badge variant="secondary" className="bg-amber-100 text-amber-800 border-amber-200 px-4 py-1.5 text-sm h-fit">
-                    {isLoading ? "Fetching..." : `${totalResults} Records Found`}
-                </Badge>
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setShowExportDialog(true)}
+                        className="border-emerald-200 text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800 hover:border-emerald-300 shadow-sm h-fit py-1.5"
+                    >
+                        <FileSpreadsheet className="w-4 h-4 mr-1.5" />
+                        Export Excel
+                    </Button>
+                    <Badge variant="secondary" className="bg-amber-100 text-amber-800 border-amber-200 px-4 py-1.5 text-sm h-fit">
+                        {isLoading ? "Fetching..." : `${totalResults} Records Found`}
+                    </Badge>
+                </div>
             </div>
             
             <div className="flex flex-col xl:flex-row gap-4 justify-between items-center bg-stone-50/50 p-2 rounded-xl border border-stone-100 min-w-0">
@@ -759,6 +871,103 @@ export function MasterlistTab(props: MasterlistTabProps) {
                             Yes, Delete Record
                         </Button>
                     </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+
+        {/* EXPORT DIALOG */}
+        <Dialog open={showExportDialog} onOpenChange={setShowExportDialog}>
+            <DialogContent className="max-w-xl p-6 bg-white rounded-xl shadow-2xl border-stone-100">
+                <DialogHeader className="mb-1">
+                    <DialogTitle className="text-xl font-bold text-stone-900 flex items-center gap-2">
+                        <FileSpreadsheet className="w-5 h-5 text-emerald-600" /> Export to Excel
+                    </DialogTitle>
+                    <DialogDescription className="text-stone-500 text-sm">
+                        Select which columns to include. Active filters (department, course, status) will be applied to the export.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {/* Active filter context */}
+                <div className="flex flex-wrap gap-1.5 py-2 border-y border-stone-100">
+                    {[
+                        { label: "Dept", value: activeDeptFilter },
+                        { label: "Course", value: activeCourseFilter },
+                        { label: "Major", value: activeMajorFilter },
+                        { label: "Status", value: activeStatusFilter },
+                    ].map(f => (
+                        <span key={f.label} className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full bg-stone-100 text-stone-500">
+                            {f.label}: <span className="text-stone-700">{f.value || "ALL"}</span>
+                        </span>
+                    ))}
+                    <span className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 ml-auto">
+                        {selectedColumns.size} col{selectedColumns.size !== 1 ? "s" : ""} selected
+                    </span>
+                </div>
+
+                {/* Global actions */}
+                <div className="flex gap-2 pt-1">
+                    <button
+                        className="text-xs text-amber-700 hover:underline font-medium"
+                        onClick={() => setSelectedColumns(new Set(EXPORT_COLUMN_GROUPS.flatMap(g => g.columns.map(c => c.key))))}
+                    >
+                        Select All
+                    </button>
+                    <span className="text-stone-300 text-xs">|</span>
+                    <button
+                        className="text-xs text-stone-400 hover:underline font-medium"
+                        onClick={() => setSelectedColumns(new Set())}
+                    >
+                        Clear All
+                    </button>
+                </div>
+
+                {/* Column groups */}
+                <div className="space-y-4 max-h-72 overflow-y-auto pr-1">
+                    {EXPORT_COLUMN_GROUPS.map(group => {
+                        const allGroupSelected = group.columns.every(c => selectedColumns.has(c.key));
+                        return (
+                            <div key={group.label}>
+                                <div className="flex items-center justify-between mb-2">
+                                    <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider">{group.label}</span>
+                                    <button
+                                        className="text-[10px] text-amber-600 hover:underline font-semibold"
+                                        onClick={() => toggleGroup(group.columns)}
+                                    >
+                                        {allGroupSelected ? "Deselect all" : "Select all"}
+                                    </button>
+                                </div>
+                                <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2">
+                                    {group.columns.map(col => (
+                                        <div key={col.key} className="flex items-center gap-2">
+                                            <Checkbox
+                                                id={col.key}
+                                                checked={selectedColumns.has(col.key)}
+                                                onCheckedChange={() => toggleColumn(col.key)}
+                                                className="border-stone-300 data-[state=checked]:bg-amber-500 data-[state=checked]:border-amber-500"
+                                            />
+                                            <Label htmlFor={col.key} className="text-sm text-stone-700 cursor-pointer font-normal leading-none">
+                                                {col.label}
+                                            </Label>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="flex gap-3 pt-3 border-t border-stone-100">
+                    <Button variant="outline" className="flex-1 border-stone-200 text-stone-600" onClick={() => setShowExportDialog(false)} disabled={isExporting}>
+                        Cancel
+                    </Button>
+                    <Button
+                        className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white shadow-sm disabled:opacity-50"
+                        onClick={handleExport}
+                        disabled={isExporting || selectedColumns.size === 0}
+                    >
+                        {isExporting ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <FileSpreadsheet className="w-4 h-4 mr-2" />}
+                        {isExporting ? "Exporting..." : "Download .xlsx"}
+                    </Button>
                 </div>
             </DialogContent>
         </Dialog>

--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -57,6 +57,23 @@ const EXPORT_COLUMN_GROUPS = [
 
 const DEFAULT_EXPORT_COLUMNS = new Set(["student_number", "first_name", "last_name", "department", "course", "major", "status"]);
 
+const STATUS_LABELS: Record<string, string> = {
+  REGISTERED:     "Registered",
+  APPROVED:       "Approved",
+  BOOKED:         "Booked",
+  ATTENDED:       "Attended",
+  FULLY_VERIFIED: "Fully Verified",
+};
+
+const EXPORT_STATUS_OPTIONS = [
+  { value: "ALL", label: "All Statuses",  color: null },
+  { value: "1",   label: "Registered",    color: "bg-stone-500" },
+  { value: "2",   label: "Approved",      color: "bg-blue-500" },
+  { value: "3",   label: "Booked",        color: "bg-orange-500" },
+  { value: "4",   label: "Attended",      color: "bg-purple-500" },
+  { value: "5",   label: "Fully Verified",color: "bg-green-600" },
+];
+
 export function MasterlistTab(props: MasterlistTabProps) {
   const {
     searchQuery, setSearchQuery, selectedStudent, setSelectedStudent,
@@ -88,6 +105,10 @@ export function MasterlistTab(props: MasterlistTabProps) {
   // Export States
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [selectedColumns, setSelectedColumns] = useState<Set<string>>(new Set(DEFAULT_EXPORT_COLUMNS));
+  const [exportDeptFilter, setExportDeptFilter] = useState("ALL");
+  const [exportCourseFilter, setExportCourseFilter] = useState("ALL");
+  const [exportMajorFilter, setExportMajorFilter] = useState("ALL");
+  const [exportStatusFilter, setExportStatusFilter] = useState("ALL");
   const [isExporting, setIsExporting] = useState(false);
 
   const getObjectKey = (url: string): string => {
@@ -243,10 +264,10 @@ export function MasterlistTab(props: MasterlistTabProps) {
     try {
       const query = new URLSearchParams({
         columns: Array.from(selectedColumns).join(","),
-        dept: activeDeptFilter || "ALL",
-        course: activeCourseFilter || "ALL",
-        major: activeMajorFilter || "ALL",
-        status: activeStatusFilter || "ALL",
+        dept: exportDeptFilter,
+        course: exportCourseFilter,
+        major: exportMajorFilter,
+        status: exportStatusFilter,
       });
       const res = await fetch(`${baseUrl}/api/admin/masterlist/export?${query}`, { credentials: "include" });
       if (!res.ok) throw new Error("Export failed");
@@ -255,7 +276,11 @@ export function MasterlistTab(props: MasterlistTabProps) {
         EXPORT_COLUMN_GROUPS.flatMap(g => g.columns.map(c => [c.key, c.label]))
       );
       const labeled = (data as Record<string, any>[]).map(row =>
-        Object.fromEntries(Object.entries(row).map(([k, v]) => [keyToLabel[k] ?? k, v]))
+        Object.fromEntries(Object.entries(row).map(([k, v]) => {
+          const header = keyToLabel[k] ?? k;
+          const value = k === "status" && typeof v === "string" ? (STATUS_LABELS[v] ?? v) : v;
+          return [header, value];
+        }))
       );
       const ws = XLSX.utils.json_to_sheet(labeled);
       const wb = XLSX.utils.book_new();
@@ -284,9 +309,15 @@ export function MasterlistTab(props: MasterlistTabProps) {
   const selectedDeptConfig = ACADEMIC_CONFIG.find((d: any) => d.name === activeDeptFilter);
   const availableCoursesConfig = selectedDeptConfig ? selectedDeptConfig.courses : [];
   const availableCourses = availableCoursesConfig.map((c: any) => c.name);
-  
+
   const selectedCourseConfig = availableCoursesConfig.find((c: any) => c.name === activeCourseFilter);
   const availableMajors = selectedCourseConfig?.majors || [];
+
+  const exportDeptConfig = ACADEMIC_CONFIG.find((d: any) => d.name === exportDeptFilter);
+  const exportCoursesConfig = exportDeptConfig ? exportDeptConfig.courses : [];
+  const exportCourses = exportCoursesConfig.map((c: any) => c.name);
+  const exportCourseConfig = exportCoursesConfig.find((c: any) => c.name === exportCourseFilter);
+  const exportMajors = exportCourseConfig?.majors || [];
 
   return (
     <div className="space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-500 w-full overflow-x-hidden">
@@ -877,7 +908,7 @@ export function MasterlistTab(props: MasterlistTabProps) {
 
         {/* EXPORT DIALOG */}
         <Dialog open={showExportDialog} onOpenChange={setShowExportDialog}>
-            <DialogContent className="max-w-xl p-6 bg-white rounded-xl shadow-2xl border-stone-100">
+            <DialogContent className="max-w-3xl p-6 bg-white rounded-xl shadow-2xl border-stone-100">
                 <DialogHeader className="mb-1">
                     <DialogTitle className="text-xl font-bold text-stone-900 flex items-center gap-2">
                         <FileSpreadsheet className="w-5 h-5 text-emerald-600" /> Export to Excel
@@ -887,21 +918,75 @@ export function MasterlistTab(props: MasterlistTabProps) {
                     </DialogDescription>
                 </DialogHeader>
 
-                {/* Active filter context */}
-                <div className="flex flex-wrap gap-1.5 py-2 border-y border-stone-100">
-                    {[
-                        { label: "Dept", value: activeDeptFilter },
-                        { label: "Course", value: activeCourseFilter },
-                        { label: "Major", value: activeMajorFilter },
-                        { label: "Status", value: activeStatusFilter },
-                    ].map(f => (
-                        <span key={f.label} className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full bg-stone-100 text-stone-500">
-                            {f.label}: <span className="text-stone-700">{f.value || "ALL"}</span>
-                        </span>
-                    ))}
-                    <span className="text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 ml-auto">
-                        {selectedColumns.size} col{selectedColumns.size !== 1 ? "s" : ""} selected
-                    </span>
+                {/* Export filters */}
+                <div className="grid grid-cols-2 gap-x-4 gap-y-2 py-2 border-y border-stone-100">
+                    {/* Department */}
+                    <div className="space-y-1 col-span-2">
+                        <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider">Department</span>
+                        <Select value={exportDeptFilter} onValueChange={v => { setExportDeptFilter(v); setExportCourseFilter("ALL"); setExportMajorFilter("ALL"); }}>
+                            <SelectTrigger className="h-8 text-xs border-stone-200 bg-white focus:ring-amber-500/20 focus:border-amber-500">
+                                <SelectValue placeholder="All Departments" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="ALL" className="text-xs">All Departments</SelectItem>
+                                {ACADEMIC_CONFIG.map((d: any) => (
+                                    <SelectItem key={d.name} value={d.name} className="text-xs">{d.name}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Course */}
+                    <div className="space-y-1 col-span-2">
+                        <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider">Course</span>
+                        <Select value={exportCourseFilter} onValueChange={v => { setExportCourseFilter(v); setExportMajorFilter("ALL"); }} disabled={exportDeptFilter === "ALL"}>
+                            <SelectTrigger className="h-8 text-xs border-stone-200 bg-white focus:ring-amber-500/20 focus:border-amber-500 disabled:opacity-50">
+                                <SelectValue placeholder={exportDeptFilter === "ALL" ? "Select dept first" : "All Courses"} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="ALL" className="text-xs">All Courses</SelectItem>
+                                {exportCourses.map((c: string) => (
+                                    <SelectItem key={c} value={c} className="text-xs">{c}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Major */}
+                    <div className="space-y-1">
+                        <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider">Major</span>
+                        <Select value={exportMajorFilter} onValueChange={setExportMajorFilter} disabled={exportCourseFilter === "ALL" || exportMajors.length === 0}>
+                            <SelectTrigger className="h-8 text-xs border-stone-200 bg-white focus:ring-amber-500/20 focus:border-amber-500 disabled:opacity-50">
+                                <SelectValue placeholder={exportCourseFilter === "ALL" ? "Select course first" : exportMajors.length === 0 ? "N/A" : "All Majors"} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="ALL" className="text-xs">All Majors</SelectItem>
+                                {exportMajors.map((m: string) => (
+                                    <SelectItem key={m} value={m} className="text-xs">{m}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Status */}
+                    <div className="space-y-1">
+                        <span className="text-[10px] font-bold text-stone-400 uppercase tracking-wider">Status</span>
+                        <Select value={exportStatusFilter} onValueChange={setExportStatusFilter}>
+                            <SelectTrigger className="h-8 text-xs border-stone-200 bg-white focus:ring-amber-500/20 focus:border-amber-500">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {EXPORT_STATUS_OPTIONS.map(opt => (
+                                    <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                                        <span className="flex items-center gap-2">
+                                            <span className={`w-2 h-2 rounded-full shrink-0 ${opt.color ?? "bg-transparent"}`} />
+                                            {opt.label}
+                                        </span>
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
                 </div>
 
                 {/* Global actions */}

--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { Search, BookOpen, GraduationCap, FileText, MapPin, Phone, Mail, Clock, Filter, User, Image as ImageIcon, X, Home, Building2, ListFilter, ChevronLeft, ChevronRight, Loader2, Download, Trash2, AlertTriangle, Send, CheckCircle2, FileSpreadsheet } from "lucide-react";
+import { Search, BookOpen, GraduationCap, FileText, MapPin, Phone, Mail, Clock, Filter, User, Image as ImageIcon, X, Home, Building2, ListFilter, ChevronLeft, ChevronRight, Loader2, Download, Trash2, AlertTriangle, Send, CheckCircle2, FileSpreadsheet, Eye, EyeOff, ShieldCheck } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -110,6 +110,13 @@ export function MasterlistTab(props: MasterlistTabProps) {
   const [exportMajorFilter, setExportMajorFilter] = useState("ALL");
   const [exportStatusFilter, setExportStatusFilter] = useState("ALL");
   const [isExporting, setIsExporting] = useState(false);
+
+  // Password Confirm States
+  const [showPasswordConfirm, setShowPasswordConfirm] = useState(false);
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState("");
+  const [isVerifyingPassword, setIsVerifyingPassword] = useState(false);
 
   const getObjectKey = (url: string): string => {
     if (typeof url !== 'string') return "";
@@ -255,11 +262,44 @@ export function MasterlistTab(props: MasterlistTabProps) {
     });
   };
 
-  const handleExport = async () => {
+  const handleExport = () => {
     if (selectedColumns.size === 0) {
       toast.error("Please select at least one column to export.");
       return;
     }
+    setConfirmPassword("");
+    setPasswordError("");
+    setShowConfirmPassword(false);
+    setShowPasswordConfirm(true);
+  };
+
+  const handleVerifyAndExport = async () => {
+    if (!confirmPassword) {
+      setPasswordError("Please enter your password.");
+      return;
+    }
+    setIsVerifyingPassword(true);
+    setPasswordError("");
+    try {
+      const verifyRes = await fetch(`${baseUrl}/api/admin/verify-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: confirmPassword }),
+        credentials: "include",
+      });
+      if (!verifyRes.ok) {
+        const body = await verifyRes.json();
+        setPasswordError(body.reason ?? "Incorrect password.");
+        return;
+      }
+    } catch {
+      setPasswordError("Could not verify. Check your connection.");
+      return;
+    } finally {
+      setIsVerifyingPassword(false);
+    }
+
+    setShowPasswordConfirm(false);
     setIsExporting(true);
     try {
       const query = new URLSearchParams({
@@ -1052,6 +1092,58 @@ export function MasterlistTab(props: MasterlistTabProps) {
                     >
                         {isExporting ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <FileSpreadsheet className="w-4 h-4 mr-2" />}
                         {isExporting ? "Exporting..." : "Download .xlsx"}
+                    </Button>
+                </div>
+            </DialogContent>
+        </Dialog>
+
+        {/* PASSWORD CONFIRM DIALOG */}
+        <Dialog open={showPasswordConfirm} onOpenChange={(open) => { if (!isVerifyingPassword) setShowPasswordConfirm(open); }}>
+            <DialogContent className="max-w-sm p-6 bg-white rounded-xl shadow-2xl border-stone-100">
+                <DialogHeader className="mb-2">
+                    <DialogTitle className="text-lg font-bold text-stone-900 flex items-center gap-2">
+                        <ShieldCheck className="w-5 h-5 text-amber-600" /> Confirm Your Identity
+                    </DialogTitle>
+                    <DialogDescription className="text-stone-500 text-sm">
+                        Enter your admin password to authorize this export.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-2 py-1">
+                    <div className="relative">
+                        <Input
+                            type={showConfirmPassword ? "text" : "password"}
+                            placeholder="Your password"
+                            value={confirmPassword}
+                            onChange={(e) => { setConfirmPassword(e.target.value); setPasswordError(""); }}
+                            onKeyDown={(e) => e.key === "Enter" && handleVerifyAndExport()}
+                            className={`pr-10 bg-stone-50 border-stone-200 focus:border-amber-500 focus:ring-amber-500/20 ${passwordError ? "border-red-400 focus:border-red-500 focus:ring-red-500/20" : ""}`}
+                            disabled={isVerifyingPassword}
+                            autoFocus
+                        />
+                        <button
+                            type="button"
+                            onClick={() => setShowConfirmPassword(p => !p)}
+                            className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+                            tabIndex={-1}
+                        >
+                            {showConfirmPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                        </button>
+                    </div>
+                    {passwordError && <p className="text-xs text-red-500 font-medium">{passwordError}</p>}
+                </div>
+
+                <div className="flex gap-3 pt-2">
+                    <Button variant="outline" className="flex-1 border-stone-200 text-stone-600" onClick={() => setShowPasswordConfirm(false)} disabled={isVerifyingPassword}>
+                        Cancel
+                    </Button>
+                    <Button
+                        className="flex-1 bg-amber-600 hover:bg-amber-700 text-white shadow-sm disabled:opacity-50"
+                        onClick={handleVerifyAndExport}
+                        disabled={isVerifyingPassword || !confirmPassword}
+                    >
+                        {isVerifyingPassword ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <ShieldCheck className="w-4 h-4 mr-2" />}
+                        {isVerifyingPassword ? "Verifying..." : "Confirm & Export"}
                     </Button>
                 </div>
             </DialogContent>


### PR DESCRIPTION
## Summary

- Add an **Export Excel** button in the MasterlistTab header (before the
  "Records Found" badge) that opens a configuration dialog.
- Export dialog lets admins choose which columns to include, organised into
  five labelled groups (Academic, Personal, Contact, Address, Family) with
  per-group and global Select All / Clear All controls.
- Four independent filter dropdowns in the dialog (Department → Course →
  Major cascade, plus Status with colour-coded dots matching the student
  card list) so the export scope is fully configurable regardless of what
  the masterlist is currently filtered to.
- Before downloading, a **Confirm Your Identity** dialog prompts for the
  admin's password, POSTs to `/api/admin/verify-password`, and only proceeds
  on success — incorrect password shows an inline error without closing the
  dialog.
- Column headers in the generated `.xlsx` use human-readable labels
  ("First Name", "Student No.", "Fully Verified") instead of raw field/enum
  names. Install: `xlsx` (SheetJS) added as a dependency.