### PR TITLE
feat: staff role management

### DIFF
--- a/src/app/admin/adminService.tsx
+++ b/src/app/admin/adminService.tsx
@@ -301,3 +301,34 @@ export async function getLiveQueue(period: string) {
         return { success: false };
     }
 }
+
+export async function fetchStaffList() {
+    try {
+        const res = await fetch(`${baseUrl}/api/admin/staff/list`, {
+            credentials: 'include'
+        });
+        const data = await res.json();
+        if (!res.ok) return { success: false, reason: data.reason };
+        return { success: true, data };
+    } catch (err) {
+        console.error("Server error:", err);
+        return { success: false };
+    }
+}
+
+export async function updateAdminRole(adminId: number, newRole: string) {
+    try {
+        const res = await fetch(`${baseUrl}/api/admin/staff/${adminId}/role`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ role: newRole }),
+            credentials: 'include'
+        });
+        const data = await res.json();
+        if (!res.ok) return { success: false, reason: data.reason };
+        return { success: true };
+    } catch (err) {
+        console.error("Server error:", err);
+        return { success: false };
+    }
+}

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -222,7 +222,7 @@ export default function AdminDashboard() {
                     {activeTab === 'masterlist' && "Verified Masterlist"}
                     {activeTab === 'scanner' && "Attendance Scanner"}
                     {activeTab === 'profile' && "My Profile"}
-                    {activeTab === 'roles' && "Manage Roles"}
+                    {activeTab === 'roles' && "Manage Staffs"}
                 </h1>
             </div>
 

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -14,9 +14,10 @@ import { VerificationTab } from "@/components/admin/tabs/VerificationTab"; // Or
 import { ProfileTab } from "@/components/admin/tabs/ProfileTab";
 import { MasterlistTab } from "@/components/admin/tabs/MasterlistTab";
 import { SchedulesTab } from "@/components/admin/tabs/SchedulesTab";
+import { RolesTab } from "@/components/admin/tabs/RolesTab";
 
 // --- MERGED IMPORTS ---
-import { NotesTab } from "@/components/admin/tabs/NotesTab"; 
+import { NotesTab } from "@/components/admin/tabs/NotesTab";
 import { GraduateReviewTab } from "@/components/admin/tabs/GraduateReviewTab"; // <--- The Renamed Staff File
 
 // Service Import
@@ -30,26 +31,29 @@ import { Admin } from "@/types";
 export default function AdminDashboard() {
   const router = useRouter();
 
-  const [activeTab, setActiveTab] = useState("verification"); 
+  const [activeTab, setActiveTab] = useState("masterlist");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  
+
   // Data States
   const [pendingStudents, setPendingStudents] = useState<any[]>([]);
-  const [currentPage, setCurrentPage] = useState(1); 
+  const [currentPage, setCurrentPage] = useState(1);
   const [totalUnverified, setTotalUnverified] = useState(0);
 
   //Cache
   const [studentCache, setStudentCache] = useState<{[page: number]: any[]}>({});
   const masterlistProps = useMasterlist();
 
-  //Schedules 
-  const { schedules, fetchSchedules } = useSchedules();  
+  //Schedules
+  const { schedules, fetchSchedules } = useSchedules();
 
   // State specific to the Graduate Review Tab (Moved from Staff)
   // This handles the "Select a student to view details" feature
   const [selectedReviewStudent, setSelectedReviewStudent] = useState<any>(null);
 
-    const [staffUser, setStaffUser] = useState<Admin | null>(null);
+  const [staffUser, setStaffUser] = useState<Admin | null>(null);
+
+  // Derived role — defaults to MEMBER until the profile loads
+  const userRole = staffUser?.role ? String(staffUser.role).toUpperCase() : 'MEMBER';
 
   const getStaffDetails = useCallback(async () => {
     try {
@@ -218,6 +222,7 @@ export default function AdminDashboard() {
                     {activeTab === 'masterlist' && "Verified Masterlist"}
                     {activeTab === 'scanner' && "Attendance Scanner"}
                     {activeTab === 'profile' && "My Profile"}
+                    {activeTab === 'roles' && "Manage Roles"}
                 </h1>
             </div>
 
@@ -260,9 +265,12 @@ export default function AdminDashboard() {
             {activeTab === 'notes' && <NotesTab />}
 
             {/* 4. OTHER ADMIN TABS */}
-            {activeTab === 'masterlist' && <MasterlistTab {...masterlistProps}/>}
-            {activeTab === 'slots' && <SchedulesTab schedules={schedules} fetchSchedules={fetchSchedules} />}
+            {activeTab === 'masterlist' && <MasterlistTab {...masterlistProps} userRole={userRole} />}
+            {activeTab === 'slots' && <SchedulesTab schedules={schedules} fetchSchedules={fetchSchedules} userRole={userRole} />}
             {activeTab === "profile" && <ProfileTab user={staffUser} setUser={setStaffUser} />}
+
+            {/* 5. ROLE MANAGEMENT — ADMINISTRATOR only */}
+            {activeTab === 'roles' && <RolesTab staffUser={staffUser} />}
         </div>
       </main>
     </div>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -90,7 +90,7 @@ export function AdminSidebar({ activeTab, setActiveTab, isMobile, setIsOpen, use
           <>
             <div className="my-2 border-t border-stone-800/50"></div>
             <p className="text-[10px] font-bold uppercase tracking-widest text-stone-600 mb-2 px-3">Management</p>
-            <NavItem id="roles" label="Manage Roles" icon={ShieldCheck} />
+            <NavItem id="roles" label="Manage Staffs" icon={ShieldCheck} />
           </>
         )}
 

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -2,10 +2,10 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { 
-  Users, Calendar, BookOpen, User, LogOut, 
-  X, Home, ExternalLink, ScanLine, 
-  ClipboardList, FileCheck 
+import {
+  Users, Calendar, BookOpen, User, LogOut,
+  X, Home, ExternalLink, ScanLine,
+  ClipboardList, FileCheck, ShieldCheck
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -23,14 +23,16 @@ interface SidebarProps {
 }
 
 export function AdminSidebar({ activeTab, setActiveTab, isMobile, setIsOpen, user, onLogout }: SidebarProps) {
-  const { isAdmin, displayPosition, userInitials } = useSidebar(user);
+  const { isAdmin, isModerator, canAccessVerification, canAccessSchedules, canManageRoles, displayPosition, userInitials } = useSidebar(user);
 
-  // Navigation item helper component
-  const NavItem = ({ id, label, icon: Icon }: any) => (
-    <Button 
-      variant="ghost" 
-      className={`w-full justify-start gap-4 h-12 text-sm font-medium transition-all ${activeTab === id ? 'bg-amber-900/30 text-amber-100 border-r-2 border-amber-500' : 'text-stone-400 hover:text-white hover:bg-stone-900'}`} 
-      onClick={() => { setActiveTab(id); if(isMobile && setIsOpen) setIsOpen(false); }}
+  const NavItem = ({ id, label, icon: Icon }: { id: string; label: string; icon: any }) => (
+    <Button
+      variant="ghost"
+      className={`w-full justify-start gap-4 h-12 text-sm font-medium transition-all ${activeTab === id ? 'bg-amber-900/30 text-amber-100 border-r-2 border-amber-500' : 'text-stone-400 hover:text-white hover:bg-stone-900'}`}
+      onClick={() => {
+        setActiveTab(id);
+        if (isMobile && setIsOpen) setIsOpen(false);
+      }}
     >
       <Icon size={18} className={activeTab === id ? "text-amber-500" : "text-stone-500"} /> {label}
     </Button>
@@ -38,57 +40,68 @@ export function AdminSidebar({ activeTab, setActiveTab, isMobile, setIsOpen, use
 
   return (
     <aside className={`${isMobile ? 'fixed inset-y-0 left-0 z-50 w-72' : 'hidden md:flex w-72 h-screen fixed left-0 top-0'} bg-stone-950 text-stone-300 flex-col border-r border-stone-800 shadow-2xl transition-transform`}>
-      
+
       <div className="p-8 border-b border-stone-800/50 flex items-center justify-between">
         <div className="flex items-center gap-3">
-            <div className="relative w-8 h-8"><Image src="/images/umtc-logo.png" alt="UMTC" fill className="object-contain" /></div>
-            <div className="h-8 w-[1px] bg-stone-700"></div>
-            <div className="relative w-8 h-8"><Image src="/images/aurium-logo.png" alt="Aurium" fill className="object-contain" /></div>
-            <div className="flex flex-col"><span className="text-lg font-serif font-bold text-white">AURIUM</span><span className="text-[8px] text-amber-600 uppercase font-bold">Admin</span></div>
+          <div className="relative w-8 h-8"><Image src="/images/umtc-logo.png" alt="UMTC" fill className="object-contain" /></div>
+          <div className="h-8 w-[1px] bg-stone-700"></div>
+          <div className="relative w-8 h-8"><Image src="/images/aurium-logo.png" alt="Aurium" fill className="object-contain" /></div>
+          <div className="flex flex-col"><span className="text-lg font-serif font-bold text-white">AURIUM</span><span className="text-[8px] text-amber-600 uppercase font-bold">Admin</span></div>
         </div>
         {isMobile && setIsOpen && <Button variant="ghost" size="icon" onClick={() => setIsOpen(false)}><X className="h-5 w-5 text-stone-400" /></Button>}
       </div>
 
       <nav className="flex-1 p-6 space-y-2 overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
         <p className="text-[10px] font-bold uppercase tracking-widest text-stone-600 mb-2 px-3">Menu</p>
-        
+
         <Link href="/" target="_blank">
-            <Button variant="ghost" className="w-full justify-start gap-4 h-12 text-sm font-medium text-stone-400 hover:text-white hover:bg-stone-900">
-                <Home size={18} /> Return to Website <ExternalLink size={12} className="opacity-50 ml-auto"/>
-            </Button>
+          <Button variant="ghost" className="w-full justify-start gap-4 h-12 text-sm font-medium text-stone-400 hover:text-white hover:bg-stone-900">
+            <Home size={18} /> Return to Website <ExternalLink size={12} className="opacity-50 ml-auto" />
+          </Button>
         </Link>
-        
+
         <div className="my-2 border-t border-stone-800/50"></div>
-        
-        {/* Admin-exclusive tabs */}
-        {isAdmin && (
-           <>
-             <NavItem id="verification" label="Verification Queue" icon={Users} />
-           </>
+
+        {/* Verification Queue — ADMINISTRATOR and MODERATOR */}
+        {canAccessVerification && (
+          <NavItem id="verification" label="Verification Queue" icon={Users} />
         )}
-        
-        <NavItem id="graduate-review" label="Graduate Verification" icon={FileCheck} />
-        
+
+        {/* Graduate Verification — ADMINISTRATOR and MODERATOR */}
+        {canAccessVerification && (
+          <NavItem id="graduate-review" label="Graduate Verification" icon={FileCheck} />
+        )}
+
         <div className="my-2 px-3 text-[10px] font-bold uppercase tracking-widest text-stone-600 mt-4">Review & Notes</div>
-        
+
+        {/* Masterlist — all roles */}
         <NavItem id="masterlist" label="Graduate Masterlist" icon={BookOpen} />
         <NavItem id="notes" label="Staff Notes" icon={ClipboardList} />
 
         <div className="my-2 border-t border-stone-800/50"></div>
 
-        {isAdmin && (
+        {/* Schedules — ADMINISTRATOR and MODERATOR */}
+        {canAccessSchedules && (
+          <NavItem id="slots" label="Schedules" icon={Calendar} />
+        )}
+
+        {/* Roles Management — ADMINISTRATOR only */}
+        {canManageRoles && (
           <>
-            <NavItem id="slots" label="Schedules" icon={Calendar} />
-            <div className="mt-4 my-2 border-t border-stone-800/50"></div>
+            <div className="my-2 border-t border-stone-800/50"></div>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-stone-600 mb-2 px-3">Management</p>
+            <NavItem id="roles" label="Manage Roles" icon={ShieldCheck} />
           </>
         )}
-        
+
+        <div className="my-2 border-t border-stone-800/50"></div>
+
         <p className="text-[10px] font-bold uppercase tracking-widest text-stone-600 mb-2 px-3">Tools</p>
 
         <Link href="/admin/scanner">
-            <Button variant="ghost" className="w-full justify-start gap-4 h-12 text-sm font-medium text-stone-400 hover:text-white hover:bg-stone-900">
-                <ScanLine size={18} /> Attendance Scanner
-            </Button>
+          <Button variant="ghost" className="w-full justify-start gap-4 h-12 text-sm font-medium text-stone-400 hover:text-white hover:bg-stone-900">
+            <ScanLine size={18} /> Attendance Scanner
+          </Button>
         </Link>
 
         <NavItem id="profile" label="My Profile" icon={User} />
@@ -96,32 +109,32 @@ export function AdminSidebar({ activeTab, setActiveTab, isMobile, setIsOpen, use
 
       <div className="p-6 border-t border-stone-800/50 bg-stone-950">
         <div className="flex items-center gap-3 mb-4">
-            <Avatar className="border-2 border-stone-600 bg-stone-800">
-                <AvatarImage src={user?.avatar || "nya"} />
-                <AvatarFallback className="text-xs font-bold text-stone-300 bg-stone-800">{userInitials}</AvatarFallback>
-            </Avatar>
-            <div className="flex-1 min-w-0">
-                <p className="text-sm font-bold text-white truncate">{user ? `${user.first_name} ${user.last_name}` : "No information"}</p>
-                <p className="text-[10px] text-amber-500 truncate uppercase tracking-wider">{displayPosition}</p>
-            </div>
+          <Avatar className="border-2 border-stone-600 bg-stone-800">
+            <AvatarImage src={user?.avatar || "nya"} />
+            <AvatarFallback className="text-xs font-bold text-stone-300 bg-stone-800">{userInitials}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-bold text-white truncate">{user ? `${user.first_name} ${user.last_name}` : "No information"}</p>
+            <p className="text-[10px] text-amber-500 truncate uppercase tracking-wider">{displayPosition}</p>
+          </div>
         </div>
         <Dialog>
-            <DialogTrigger asChild>
-                <Button variant="ghost" className="w-full justify-start gap-3 text-red-400 hover:text-red-300 hover:bg-red-900/20">
-                    <LogOut size={18} /> Log Out
-                </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md rounded-2xl">
-                <DialogHeader>
-                    <DialogTitle>Confirm Logout</DialogTitle>
-                    <DialogDescription>End session?</DialogDescription>
-                </DialogHeader>
-                <DialogFooter>
-                    <Link href="/" onClick={onLogout}>
-                        <Button variant="destructive" className="w-full">Yes, Log Out</Button>
-                    </Link>
-                </DialogFooter>
-            </DialogContent>
+          <DialogTrigger asChild>
+            <Button variant="ghost" className="w-full justify-start gap-3 text-red-400 hover:text-red-300 hover:bg-red-900/20">
+              <LogOut size={18} /> Log Out
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md rounded-2xl">
+            <DialogHeader>
+              <DialogTitle>Confirm Logout</DialogTitle>
+              <DialogDescription>End session?</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Link href="/" onClick={onLogout}>
+                <Button variant="destructive" className="w-full">Yes, Log Out</Button>
+              </Link>
+            </DialogFooter>
+          </DialogContent>
         </Dialog>
       </div>
     </aside>

--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -89,6 +89,7 @@ export function MasterlistTab(props: MasterlistTabProps) {
 
   const canSendOtp = userRole === 'ADMINISTRATOR' || userRole === 'MODERATOR';
   const canDeleteStudent = userRole === 'ADMINISTRATOR';
+  const canExport = userRole === 'ADMINISTRATOR' || userRole === 'MODERATOR';
 
   const [enlargedImage, setEnlargedImage] = useState<string | null>(null);
   
@@ -369,15 +370,17 @@ export function MasterlistTab(props: MasterlistTabProps) {
                     </p>
                 </div>
                 <div className="flex items-center gap-2">
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setShowExportDialog(true)}
-                        className="border-emerald-200 text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800 hover:border-emerald-300 shadow-sm h-fit py-1.5"
-                    >
-                        <FileSpreadsheet className="w-4 h-4 mr-1.5" />
-                        Export Excel
-                    </Button>
+                    {canExport && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setShowExportDialog(true)}
+                            className="border-emerald-200 text-emerald-700 hover:bg-emerald-50 hover:text-emerald-800 hover:border-emerald-300 shadow-sm h-fit py-1.5"
+                        >
+                            <FileSpreadsheet className="w-4 h-4 mr-1.5" />
+                            Export Excel
+                        </Button>
+                    )}
                     <Badge variant="secondary" className="bg-amber-100 text-amber-800 border-amber-200 px-4 py-1.5 text-sm h-fit">
                         {isLoading ? "Fetching..." : `${totalResults} Records Found`}
                     </Badge>

--- a/src/components/admin/tabs/MasterlistTab.tsx
+++ b/src/components/admin/tabs/MasterlistTab.tsx
@@ -14,7 +14,7 @@ import * as XLSX from "xlsx";
 import { useMasterlist } from "@/hooks/useMasterlist";
 import * as adminService from "@/app/admin/adminService";
 
-type MasterlistTabProps = ReturnType<typeof useMasterlist>;
+type MasterlistTabProps = ReturnType<typeof useMasterlist> & { userRole: string };
 const baseUrl = process.env.NEXT_PUBLIC_LOCAL_URL || "";
 
 const EXPORT_COLUMN_GROUPS = [
@@ -77,14 +77,18 @@ const EXPORT_STATUS_OPTIONS = [
 export function MasterlistTab(props: MasterlistTabProps) {
   const {
     searchQuery, setSearchQuery, selectedStudent, setSelectedStudent,
-    activeDeptFilter, setActiveDeptFilter, 
+    activeDeptFilter, setActiveDeptFilter,
     activeCourseFilter, setActiveCourseFilter,
-    activeStatusFilter, setActiveStatusFilter,  
+    activeStatusFilter, setActiveStatusFilter,
     activeMajorFilter, setActiveMajorFilter,
     currentPage, setCurrentPage, students, totalResults, isLoading, ITEMS_PER_PAGE,
     handleSearchClick, handleLoadClick, handleSearchKeyDown,
     DEPARTMENT_ORDER, STATUS_STEPS, ACADEMIC_CONFIG,
-  } = props as any; 
+    userRole,
+  } = props as any;
+
+  const canSendOtp = userRole === 'ADMINISTRATOR' || userRole === 'MODERATOR';
+  const canDeleteStudent = userRole === 'ADMINISTRATOR';
 
   const [enlargedImage, setEnlargedImage] = useState<string | null>(null);
   
@@ -669,16 +673,18 @@ export function MasterlistTab(props: MasterlistTabProps) {
                                 </div>
                             </div>
                             
-                            <div className="mt-auto pt-10 w-full">
-                                <Button 
-                                    variant="outline" 
-                                    className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 hover:border-red-300 font-semibold transition-colors"
-                                    onClick={() => setShowDeleteConfirm(true)}
-                                >
-                                    <Trash2 size={16} className="mr-2" />
-                                    Remove Student Record
-                                </Button>
-                            </div>
+                            {canDeleteStudent && (
+                                <div className="mt-auto pt-10 w-full">
+                                    <Button
+                                        variant="outline"
+                                        className="w-full border-red-200 text-red-600 hover:bg-red-50 hover:text-red-700 hover:border-red-300 font-semibold transition-colors"
+                                        onClick={() => setShowDeleteConfirm(true)}
+                                    >
+                                        <Trash2 size={16} className="mr-2" />
+                                        Remove Student Record
+                                    </Button>
+                                </div>
+                            )}
                         </div>
 
                         <div className="flex-1 bg-white p-8 md:p-10 overflow-y-auto">
@@ -837,34 +843,36 @@ export function MasterlistTab(props: MasterlistTabProps) {
                         Save Email Changes (WIP)
                     </Button>
                     
-                    <div className="relative w-full pt-4 border-t border-stone-100">
-                        <label className="text-[10px] font-bold text-stone-400 uppercase tracking-wider block mb-2">Resend Verification Code</label>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                            <Button 
-                                onClick={() => setOtpConfirmTarget('personal')} 
-                                disabled={hasUnsavedEmailChanges || !isPersonalEmailValid} 
-                                variant="outline" 
-                                className="w-full border-amber-200 text-amber-700 hover:bg-amber-50 hover:text-amber-800 disabled:opacity-50"
-                            >
-                                <Send className="w-4 h-4 mr-2" />
-                                To Personal
-                            </Button>
-                            <Button 
-                                onClick={() => setOtpConfirmTarget('school')} 
-                                disabled={hasUnsavedEmailChanges || !editSchoolEmail || !isSchoolEmailValid} 
-                                variant="outline" 
-                                className="w-full border-amber-200 text-amber-700 hover:bg-amber-50 hover:text-amber-800 disabled:opacity-50"
-                            >
-                                <Send className="w-4 h-4 mr-2" />
-                                To School
-                            </Button>
+                    {canSendOtp && (
+                        <div className="relative w-full pt-4 border-t border-stone-100">
+                            <label className="text-[10px] font-bold text-stone-400 uppercase tracking-wider block mb-2">Resend Verification Code</label>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                                <Button
+                                    onClick={() => setOtpConfirmTarget('personal')}
+                                    disabled={hasUnsavedEmailChanges || !isPersonalEmailValid}
+                                    variant="outline"
+                                    className="w-full border-amber-200 text-amber-700 hover:bg-amber-50 hover:text-amber-800 disabled:opacity-50"
+                                >
+                                    <Send className="w-4 h-4 mr-2" />
+                                    To Personal
+                                </Button>
+                                <Button
+                                    onClick={() => setOtpConfirmTarget('school')}
+                                    disabled={hasUnsavedEmailChanges || !editSchoolEmail || !isSchoolEmailValid}
+                                    variant="outline"
+                                    className="w-full border-amber-200 text-amber-700 hover:bg-amber-50 hover:text-amber-800 disabled:opacity-50"
+                                >
+                                    <Send className="w-4 h-4 mr-2" />
+                                    To School
+                                </Button>
+                            </div>
+                            {hasUnsavedEmailChanges && (
+                                <p className="text-[10px] text-red-500 text-center mt-2 absolute -bottom-5 w-full">
+                                    *Please save your email changes before resending the OTP.
+                                </p>
+                            )}
                         </div>
-                        {hasUnsavedEmailChanges && (
-                            <p className="text-[10px] text-red-500 text-center mt-2 absolute -bottom-5 w-full">
-                                *Please save your email changes before resending the OTP.
-                            </p>
-                        )}
-                    </div>
+                    )}
                 </div>
             </DialogContent>
         </Dialog>

--- a/src/components/admin/tabs/RolesTab.tsx
+++ b/src/components/admin/tabs/RolesTab.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { ShieldCheck, RefreshCw, Loader2, Mail, Clock } from "lucide-react";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { ShieldCheck, Shield, RefreshCw, Loader2, Mail, Clock, Save, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Admin } from "@/types";
@@ -23,32 +22,57 @@ interface RolesTabProps {
   staffUser: Admin | null;
 }
 
-const ROLE_OPTIONS = [
-  { value: "MODERATOR", label: "Moderator" },
-  { value: "MEMBER", label: "Member" },
-];
+const ROLE_ICONS: Record<string, React.ElementType> = {
+  MODERATOR: ShieldCheck,
+  MEMBER: Shield,
+};
 
-const ROLE_STYLES: Record<string, string> = {
-  MODERATOR: "bg-blue-100 text-blue-800 border-blue-200",
-  MEMBER: "bg-stone-100 text-stone-600 border-stone-200",
+const ROLE_COLORS: Record<string, { badge: string; icon: string; row: string }> = {
+  MODERATOR: { badge: "bg-blue-100 text-blue-800 border-blue-200", icon: "text-blue-600", row: "border-l-2 border-l-blue-400 bg-blue-50/40" },
+  MEMBER:    { badge: "bg-stone-100 text-stone-600 border-stone-200", icon: "text-stone-400", row: "" },
 };
 
 const ROLE_DESCRIPTIONS: Record<string, string> = {
   MODERATOR: "Can manage verification, graduation, masterlist, and close/open schedules. Can send OTP.",
-  MEMBER: "Read-only access to masterlist and staff notes only.",
+  MEMBER:    "Read-only access to masterlist and staff notes only.",
 };
+
+const ROLE_OPTIONS = [
+  { value: "MODERATOR", label: "Moderator" },
+  { value: "MEMBER",    label: "Member" },
+];
+
+function RoleChip({ role, size = "sm" }: { role: string; size?: "sm" | "xs" }) {
+  const Icon = ROLE_ICONS[role] ?? Shield;
+  const colors = ROLE_COLORS[role] ?? ROLE_COLORS.MEMBER;
+  const label = role.charAt(0) + role.slice(1).toLowerCase();
+  const sizeClass = size === "xs" ? "text-[10px] px-1.5 py-0.5 gap-1" : "text-xs px-2 py-0.5 gap-1.5";
+  const iconSize = size === "xs" ? 10 : 12;
+
+  return (
+    <span className={`inline-flex items-center font-semibold rounded-md border ${colors.badge} ${sizeClass}`}>
+      <Icon size={iconSize} className={colors.icon} />
+      {label}
+    </span>
+  );
+}
 
 export function RolesTab({ staffUser }: RolesTabProps) {
   const [staffList, setStaffList] = useState<StaffMember[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Pending role change that requires confirmation
-  const [pendingChange, setPendingChange] = useState<{
-    member: StaffMember;
-    newRole: string;
-  } | null>(null);
+  // Local role overrides — keys are member IDs, values are the new role string
+  const [localRoles, setLocalRoles] = useState<Record<number, string>>({});
 
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
+
+  // Rows that differ from the server state
+  const pendingChanges = useMemo(() => {
+    return staffList.filter(m => localRoles[m.id] !== undefined && localRoles[m.id] !== m.role);
+  }, [staffList, localRoles]);
+
+  const hasPendingChanges = pendingChanges.length > 0;
 
   const loadStaffList = useCallback(async () => {
     setIsLoading(true);
@@ -59,6 +83,7 @@ export function RolesTab({ staffUser }: RolesTabProps) {
         return;
       }
       setStaffList(result.data as StaffMember[]);
+      setLocalRoles({});
     } catch {
       toast.error("Could not connect to the server.");
     } finally {
@@ -74,45 +99,46 @@ export function RolesTab({ staffUser }: RolesTabProps) {
     if (!dateString) return "Never";
     const date = new Date(dateString);
     if (isNaN(date.getTime())) return "Unknown";
-    return date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "2-digit",
-      year: "numeric",
-    });
+    return date.toLocaleDateString("en-US", { month: "short", day: "2-digit", year: "numeric" });
   };
 
-  const handleRoleSelectChange = (member: StaffMember, newRole: string) => {
-    if (newRole === member.role) return;
-    setPendingChange({ member, newRole });
+  const handleRoleSelectChange = (memberId: number, newRole: string) => {
+    setLocalRoles(prev => ({ ...prev, [memberId]: newRole }));
   };
 
-  const confirmRoleChange = async () => {
-    if (!pendingChange) return;
+  const discardChanges = () => {
+    setLocalRoles({});
+  };
 
+  // Fires all pending role updates in parallel, then refreshes server state
+  const confirmAllChanges = async () => {
     setIsUpdating(true);
     try {
-      const result = await adminService.updateAdminRole(pendingChange.member.id, pendingChange.newRole);
-      if (!result.success) {
-        toast.error((result as any).reason || "Failed to update role.");
-        return;
+      const results = await Promise.all(
+        pendingChanges.map(m => adminService.updateAdminRole(m.id, localRoles[m.id]))
+      );
+
+      const failedCount = results.filter(r => !r.success).length;
+
+      if (failedCount > 0) {
+        toast.error(`${failedCount} update(s) failed. Refreshing to show current state.`);
+      } else {
+        toast.success(`${pendingChanges.length} role(s) updated successfully.`);
       }
 
-      setStaffList(prev =>
-        prev.map(m =>
-          m.id === pendingChange.member.id ? { ...m, role: pendingChange.newRole } : m
-        )
-      );
-
-      toast.success(
-        `${pendingChange.member.first_name} ${pendingChange.member.last_name}'s role updated to ${pendingChange.newRole}.`
-      );
-      setPendingChange(null);
+      // Refresh from server to get authoritative state
+      await loadStaffList();
+      setShowConfirmDialog(false);
     } catch {
       toast.error("Something went wrong. Please try again.");
     } finally {
       setIsUpdating(false);
     }
   };
+
+  // The displayed role for a member is local override if set, otherwise server role
+  const getDisplayRole = (member: StaffMember) => localRoles[member.id] ?? member.role;
+  const isDirty = (member: StaffMember) => localRoles[member.id] !== undefined && localRoles[member.id] !== member.role;
 
   return (
     <div className="space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
@@ -125,7 +151,7 @@ export function RolesTab({ staffUser }: RolesTabProps) {
               <ShieldCheck className="h-6 w-6 text-amber-600" /> Staff Role Management
             </h2>
             <p className="text-sm text-stone-500 mt-1">
-              Assign roles to staff members. Only Moderator and Member roles can be assigned here.
+              Adjust roles across multiple staff members, then save all changes at once.
             </p>
           </div>
           <Button
@@ -147,9 +173,9 @@ export function RolesTab({ staffUser }: RolesTabProps) {
         <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-3">
           {ROLE_OPTIONS.map(opt => (
             <div key={opt.value} className="flex items-start gap-3 p-3 rounded-xl bg-stone-50 border border-stone-100">
-              <Badge className={`mt-0.5 shrink-0 border text-xs font-semibold ${ROLE_STYLES[opt.value]}`}>
-                {opt.label}
-              </Badge>
+              <div className="mt-0.5 shrink-0">
+                <RoleChip role={opt.value} />
+              </div>
               <p className="text-xs text-stone-500 leading-relaxed">{ROLE_DESCRIPTIONS[opt.value]}</p>
             </div>
           ))}
@@ -183,97 +209,144 @@ export function RolesTab({ staffUser }: RolesTabProps) {
               <span className="col-span-4 text-[10px] font-bold uppercase tracking-widest text-stone-500">Role</span>
             </div>
 
-            {staffList.map(member => (
-              <div
-                key={member.id}
-                className="grid grid-cols-12 items-center px-6 py-4 hover:bg-stone-50/60 transition-colors"
-              >
-                {/* Name + Email */}
-                <div className="col-span-5 min-w-0">
-                  <p className="text-sm font-semibold text-stone-800 truncate">
-                    {member.last_name}, {member.first_name}
-                  </p>
-                  <div className="flex items-center gap-1 mt-0.5">
-                    <Mail size={11} className="text-stone-400 shrink-0" />
-                    <p className="text-xs text-stone-400 truncate">{member.email}</p>
+            {staffList.map(member => {
+              const dirty = isDirty(member);
+              const displayRole = getDisplayRole(member);
+
+              return (
+                <div
+                  key={member.id}
+                  className={`grid grid-cols-12 items-center px-6 py-4 transition-colors ${dirty ? "bg-amber-50/50" : "hover:bg-stone-50/60"}`}
+                >
+                  {/* Name + Email */}
+                  <div className="col-span-5 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-semibold text-stone-800 truncate">
+                        {member.last_name}, {member.first_name}
+                      </p>
+                      {dirty && (
+                        <span className="shrink-0 text-[9px] font-bold uppercase tracking-wider text-amber-700 bg-amber-100 border border-amber-200 rounded px-1 py-0.5">
+                          Changed
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 mt-0.5">
+                      <Mail size={11} className="text-stone-400 shrink-0" />
+                      <p className="text-xs text-stone-400 truncate">{member.email}</p>
+                    </div>
+                  </div>
+
+                  {/* Last Login */}
+                  <div className="col-span-3 hidden sm:flex items-center gap-1.5 text-xs text-stone-500">
+                    <Clock size={12} className="text-stone-400 shrink-0" />
+                    {formatLastLogin(member.last_login)}
+                  </div>
+
+                  {/* Role Select */}
+                  <div className="col-span-4">
+                    <Select
+                      value={displayRole}
+                      onValueChange={(newRole) => handleRoleSelectChange(member.id, newRole)}
+                    >
+                      <SelectTrigger className={`h-9 text-sm bg-white focus:ring-amber-500/20 focus:border-amber-500 transition-colors ${dirty ? "border-amber-400" : "border-stone-200"}`}>
+                        <SelectValue>
+                          <RoleChip role={displayRole} />
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ROLE_OPTIONS.map(opt => {
+                          const Icon = ROLE_ICONS[opt.value];
+                          const colors = ROLE_COLORS[opt.value];
+                          return (
+                            <SelectItem key={opt.value} value={opt.value}>
+                              <div className="flex items-center gap-2">
+                                <Icon size={14} className={colors.icon} />
+                                {opt.label}
+                              </div>
+                            </SelectItem>
+                          );
+                        })}
+                      </SelectContent>
+                    </Select>
                   </div>
                 </div>
-
-                {/* Last Login */}
-                <div className="col-span-3 hidden sm:flex items-center gap-1.5 text-xs text-stone-500">
-                  <Clock size={12} className="text-stone-400 shrink-0" />
-                  {formatLastLogin(member.last_login)}
-                </div>
-
-                {/* Role Select */}
-                <div className="col-span-4">
-                  <Select
-                    value={member.role}
-                    onValueChange={(newRole) => handleRoleSelectChange(member, newRole)}
-                  >
-                    <SelectTrigger className="h-9 text-sm border-stone-200 bg-white focus:ring-amber-500/20 focus:border-amber-500">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {ROLE_OPTIONS.map(opt => (
-                        <SelectItem key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
 
+      {/* Save / Discard Bar — appears when there are unsaved changes */}
+      {hasPendingChanges && (
+        <div className="sticky bottom-4 z-10 flex items-center justify-between gap-3 bg-white px-5 py-3.5 rounded-2xl shadow-lg border border-amber-200 animate-in slide-in-from-bottom-2 duration-200">
+          <p className="text-sm font-medium text-stone-700">
+            <span className="text-amber-700 font-bold">{pendingChanges.length}</span>{" "}
+            unsaved change{pendingChanges.length > 1 ? "s" : ""}
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={discardChanges}
+              className="text-stone-500 hover:text-stone-800 hover:bg-stone-100 h-8"
+            >
+              <RotateCcw className="w-3.5 h-3.5 mr-1.5" />
+              Discard
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => setShowConfirmDialog(true)}
+              className="bg-amber-700 hover:bg-amber-800 text-white h-8 px-4 shadow-sm"
+            >
+              <Save className="w-3.5 h-3.5 mr-1.5" />
+              Save Changes
+            </Button>
+          </div>
+        </div>
+      )}
+
       {/* Confirmation Dialog */}
-      <Dialog open={!!pendingChange} onOpenChange={(open) => { if (!open) setPendingChange(null); }}>
+      <Dialog open={showConfirmDialog} onOpenChange={(open) => { if (!open && !isUpdating) setShowConfirmDialog(false); }}>
         <DialogContent className="max-w-md rounded-2xl">
           <DialogHeader>
-            <DialogTitle className="text-lg font-bold text-stone-900">Confirm Role Change</DialogTitle>
+            <DialogTitle className="text-lg font-bold text-stone-900">Save Role Changes?</DialogTitle>
             <DialogDescription className="text-stone-500 text-sm mt-1">
-              You are about to change{" "}
-              <span className="font-semibold text-stone-800">
-                {pendingChange?.member.first_name} {pendingChange?.member.last_name}
-              </span>
-              {"'s"} role from{" "}
-              <Badge className={`inline-flex border text-xs ${ROLE_STYLES[pendingChange?.member.role ?? "MEMBER"]}`}>
-                {pendingChange?.member.role}
-              </Badge>
-              {" "}to{" "}
-              <Badge className={`inline-flex border text-xs ${ROLE_STYLES[pendingChange?.newRole ?? "MEMBER"]}`}>
-                {pendingChange?.newRole}
-              </Badge>
-              .
+              The following {pendingChanges.length} role update{pendingChanges.length > 1 ? "s" : ""} will be applied:
             </DialogDescription>
           </DialogHeader>
 
-          {pendingChange && (
-            <div className="mt-2 p-3 bg-amber-50 border border-amber-100 rounded-xl text-xs text-amber-800 leading-relaxed">
-              <strong>New permissions:</strong> {ROLE_DESCRIPTIONS[pendingChange.newRole]}
-            </div>
-          )}
+          <div className="mt-1 divide-y divide-stone-100 rounded-xl border border-stone-200 overflow-hidden">
+            {pendingChanges.map(m => (
+              <div key={m.id} className="flex items-center justify-between px-4 py-2.5 bg-white">
+                <p className="text-sm font-medium text-stone-800 truncate">
+                  {m.last_name}, {m.first_name}
+                </p>
+                <div className="flex items-center gap-2 shrink-0">
+                  <RoleChip role={m.role} size="xs" />
+                  <span className="text-stone-400 text-xs">→</span>
+                  <RoleChip role={localRoles[m.id]} size="xs" />
+                </div>
+              </div>
+            ))}
+          </div>
 
           <DialogFooter className="mt-4 flex gap-2">
             <Button
               variant="outline"
               className="flex-1 border-stone-200"
-              onClick={() => setPendingChange(null)}
+              onClick={() => setShowConfirmDialog(false)}
               disabled={isUpdating}
             >
               Cancel
             </Button>
             <Button
               className="flex-1 bg-amber-700 hover:bg-amber-800 text-white"
-              onClick={confirmRoleChange}
+              onClick={confirmAllChanges}
               disabled={isUpdating}
             >
               {isUpdating
                 ? <><Loader2 className="w-4 h-4 animate-spin mr-2" /> Saving...</>
-                : "Confirm Change"
+                : `Apply ${pendingChanges.length} Change${pendingChanges.length > 1 ? "s" : ""}`
               }
             </Button>
           </DialogFooter>

--- a/src/components/admin/tabs/RolesTab.tsx
+++ b/src/components/admin/tabs/RolesTab.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { ShieldCheck, Shield, RefreshCw, Loader2, Mail, Clock, Save, RotateCcw } from "lucide-react";
+import { ShieldCheck, Shield, RefreshCw, Loader2, Mail, Clock, Save, RotateCcw, Eye, EyeOff, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Admin } from "@/types";
 import * as adminService from "@/app/admin/adminService";
 import toast from "react-hot-toast";
+
+const baseUrl = process.env.NEXT_PUBLIC_LOCAL_URL || "";
 
 interface StaffMember {
   id: number;
@@ -27,9 +30,9 @@ const ROLE_ICONS: Record<string, React.ElementType> = {
   MEMBER: Shield,
 };
 
-const ROLE_COLORS: Record<string, { badge: string; icon: string; row: string }> = {
-  MODERATOR: { badge: "bg-blue-100 text-blue-800 border-blue-200", icon: "text-blue-600", row: "border-l-2 border-l-blue-400 bg-blue-50/40" },
-  MEMBER:    { badge: "bg-stone-100 text-stone-600 border-stone-200", icon: "text-stone-400", row: "" },
+const ROLE_COLORS: Record<string, { badge: string; icon: string }> = {
+  MODERATOR: { badge: "bg-blue-100 text-blue-800 border-blue-200", icon: "text-blue-600" },
+  MEMBER:    { badge: "bg-stone-100 text-stone-600 border-stone-200", icon: "text-stone-400" },
 };
 
 const ROLE_DESCRIPTIONS: Record<string, string> = {
@@ -66,6 +69,12 @@ export function RolesTab({ staffUser }: RolesTabProps) {
 
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
+
+  // Password verification state
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState("");
+  const [isVerifying, setIsVerifying] = useState(false);
 
   // Rows that differ from the server state
   const pendingChanges = useMemo(() => {
@@ -110,8 +119,43 @@ export function RolesTab({ staffUser }: RolesTabProps) {
     setLocalRoles({});
   };
 
-  // Fires all pending role updates in parallel, then refreshes server state
+  const closeConfirmDialog = () => {
+    if (isUpdating || isVerifying) return;
+    setShowConfirmDialog(false);
+    setPassword("");
+    setShowPassword(false);
+    setPasswordError("");
+  };
+
+  // Step 1: verify password. Step 2: apply all pending changes in parallel.
   const confirmAllChanges = async () => {
+    if (!password) {
+      setPasswordError("Please enter your password.");
+      return;
+    }
+
+    setIsVerifying(true);
+    setPasswordError("");
+    try {
+      const verifyRes = await fetch(`${baseUrl}/api/admin/verify-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+        credentials: "include",
+      });
+
+      if (!verifyRes.ok) {
+        const body = await verifyRes.json();
+        setPasswordError(body.reason ?? "Incorrect password.");
+        return;
+      }
+    } catch {
+      setPasswordError("Could not verify. Check your connection.");
+      return;
+    } finally {
+      setIsVerifying(false);
+    }
+
     setIsUpdating(true);
     try {
       const results = await Promise.all(
@@ -126,9 +170,8 @@ export function RolesTab({ staffUser }: RolesTabProps) {
         toast.success(`${pendingChanges.length} role(s) updated successfully.`);
       }
 
-      // Refresh from server to get authoritative state
       await loadStaffList();
-      setShowConfirmDialog(false);
+      closeConfirmDialog();
     } catch {
       toast.error("Something went wrong. Please try again.");
     } finally {
@@ -136,7 +179,6 @@ export function RolesTab({ staffUser }: RolesTabProps) {
     }
   };
 
-  // The displayed role for a member is local override if set, otherwise server role
   const getDisplayRole = (member: StaffMember) => localRoles[member.id] ?? member.role;
   const isDirty = (member: StaffMember) => localRoles[member.id] !== undefined && localRoles[member.id] !== member.role;
 
@@ -305,8 +347,8 @@ export function RolesTab({ staffUser }: RolesTabProps) {
         </div>
       )}
 
-      {/* Confirmation Dialog */}
-      <Dialog open={showConfirmDialog} onOpenChange={(open) => { if (!open && !isUpdating) setShowConfirmDialog(false); }}>
+      {/* Confirmation Dialog with password gate */}
+      <Dialog open={showConfirmDialog} onOpenChange={(open) => { if (!open) closeConfirmDialog(); }}>
         <DialogContent className="max-w-md rounded-2xl">
           <DialogHeader>
             <DialogTitle className="text-lg font-bold text-stone-900">Save Role Changes?</DialogTitle>
@@ -315,6 +357,7 @@ export function RolesTab({ staffUser }: RolesTabProps) {
             </DialogDescription>
           </DialogHeader>
 
+          {/* Changes summary */}
           <div className="mt-1 divide-y divide-stone-100 rounded-xl border border-stone-200 overflow-hidden">
             {pendingChanges.map(m => (
               <div key={m.id} className="flex items-center justify-between px-4 py-2.5 bg-white">
@@ -330,21 +373,51 @@ export function RolesTab({ staffUser }: RolesTabProps) {
             ))}
           </div>
 
+          {/* Password field */}
+          <div className="mt-4 space-y-1.5">
+            <label className="text-[10px] font-bold uppercase tracking-widest text-stone-500 flex items-center gap-1.5">
+              <Lock size={10} /> Confirm your password to proceed
+            </label>
+            <div className="relative">
+              <Input
+                type={showPassword ? "text" : "password"}
+                placeholder="Enter your password"
+                value={password}
+                onChange={(e) => { setPassword(e.target.value); setPasswordError(""); }}
+                onKeyDown={(e) => { if (e.key === "Enter") confirmAllChanges(); }}
+                className={`pr-10 bg-stone-50 focus:ring-amber-500/20 focus:border-amber-500 ${passwordError ? "border-red-400" : "border-stone-200"}`}
+                disabled={isUpdating || isVerifying}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(prev => !prev)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-400 hover:text-stone-600"
+              >
+                {showPassword ? <EyeOff size={15} /> : <Eye size={15} />}
+              </button>
+            </div>
+            {passwordError && (
+              <p className="text-xs text-red-500 font-medium">{passwordError}</p>
+            )}
+          </div>
+
           <DialogFooter className="mt-4 flex gap-2">
             <Button
               variant="outline"
               className="flex-1 border-stone-200"
-              onClick={() => setShowConfirmDialog(false)}
-              disabled={isUpdating}
+              onClick={closeConfirmDialog}
+              disabled={isUpdating || isVerifying}
             >
               Cancel
             </Button>
             <Button
               className="flex-1 bg-amber-700 hover:bg-amber-800 text-white"
               onClick={confirmAllChanges}
-              disabled={isUpdating}
+              disabled={isUpdating || isVerifying || !password}
             >
-              {isUpdating
+              {isVerifying
+                ? <><Loader2 className="w-4 h-4 animate-spin mr-2" /> Verifying...</>
+                : isUpdating
                 ? <><Loader2 className="w-4 h-4 animate-spin mr-2" /> Saving...</>
                 : `Apply ${pendingChanges.length} Change${pendingChanges.length > 1 ? "s" : ""}`
               }

--- a/src/components/admin/tabs/RolesTab.tsx
+++ b/src/components/admin/tabs/RolesTab.tsx
@@ -190,10 +190,10 @@ export function RolesTab({ staffUser }: RolesTabProps) {
         <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4">
           <div>
             <h2 className="text-xl font-bold text-stone-800 flex items-center gap-2">
-              <ShieldCheck className="h-6 w-6 text-amber-600" /> Staff Role Management
+              <ShieldCheck className="h-6 w-6 text-amber-600" /> Staff Management
             </h2>
             <p className="text-sm text-stone-500 mt-1">
-              Adjust roles across multiple staff members, then save all changes at once.
+              Manage your staff members by adjusting their roles
             </p>
           </div>
           <Button

--- a/src/components/admin/tabs/RolesTab.tsx
+++ b/src/components/admin/tabs/RolesTab.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { ShieldCheck, RefreshCw, Loader2, Mail, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Admin } from "@/types";
+import * as adminService from "@/app/admin/adminService";
+import toast from "react-hot-toast";
+
+interface StaffMember {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  role: string;
+  last_login: string | null;
+}
+
+interface RolesTabProps {
+  staffUser: Admin | null;
+}
+
+const ROLE_OPTIONS = [
+  { value: "MODERATOR", label: "Moderator" },
+  { value: "MEMBER", label: "Member" },
+];
+
+const ROLE_STYLES: Record<string, string> = {
+  MODERATOR: "bg-blue-100 text-blue-800 border-blue-200",
+  MEMBER: "bg-stone-100 text-stone-600 border-stone-200",
+};
+
+const ROLE_DESCRIPTIONS: Record<string, string> = {
+  MODERATOR: "Can manage verification, graduation, masterlist, and close/open schedules. Can send OTP.",
+  MEMBER: "Read-only access to masterlist and staff notes only.",
+};
+
+export function RolesTab({ staffUser }: RolesTabProps) {
+  const [staffList, setStaffList] = useState<StaffMember[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Pending role change that requires confirmation
+  const [pendingChange, setPendingChange] = useState<{
+    member: StaffMember;
+    newRole: string;
+  } | null>(null);
+
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const loadStaffList = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const result = await adminService.fetchStaffList();
+      if (!result.success) {
+        toast.error("Failed to load staff list.");
+        return;
+      }
+      setStaffList(result.data as StaffMember[]);
+    } catch {
+      toast.error("Could not connect to the server.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStaffList();
+  }, [loadStaffList]);
+
+  const formatLastLogin = (dateString: string | null) => {
+    if (!dateString) return "Never";
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return "Unknown";
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+    });
+  };
+
+  const handleRoleSelectChange = (member: StaffMember, newRole: string) => {
+    if (newRole === member.role) return;
+    setPendingChange({ member, newRole });
+  };
+
+  const confirmRoleChange = async () => {
+    if (!pendingChange) return;
+
+    setIsUpdating(true);
+    try {
+      const result = await adminService.updateAdminRole(pendingChange.member.id, pendingChange.newRole);
+      if (!result.success) {
+        toast.error((result as any).reason || "Failed to update role.");
+        return;
+      }
+
+      setStaffList(prev =>
+        prev.map(m =>
+          m.id === pendingChange.member.id ? { ...m, role: pendingChange.newRole } : m
+        )
+      );
+
+      toast.success(
+        `${pendingChange.member.first_name} ${pendingChange.member.last_name}'s role updated to ${pendingChange.newRole}.`
+      );
+      setPendingChange(null);
+    } catch {
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
+
+      {/* Header */}
+      <div className="bg-white p-6 rounded-2xl border border-stone-200 shadow-sm">
+        <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4">
+          <div>
+            <h2 className="text-xl font-bold text-stone-800 flex items-center gap-2">
+              <ShieldCheck className="h-6 w-6 text-amber-600" /> Staff Role Management
+            </h2>
+            <p className="text-sm text-stone-500 mt-1">
+              Assign roles to staff members. Only Moderator and Member roles can be assigned here.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={loadStaffList}
+            disabled={isLoading}
+            className="border-stone-200 text-stone-600 hover:bg-stone-50 h-fit py-1.5 shrink-0"
+          >
+            {isLoading
+              ? <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+              : <RefreshCw className="w-4 h-4 mr-1.5" />
+            }
+            Refresh
+          </Button>
+        </div>
+
+        {/* Role Legend */}
+        <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {ROLE_OPTIONS.map(opt => (
+            <div key={opt.value} className="flex items-start gap-3 p-3 rounded-xl bg-stone-50 border border-stone-100">
+              <Badge className={`mt-0.5 shrink-0 border text-xs font-semibold ${ROLE_STYLES[opt.value]}`}>
+                {opt.label}
+              </Badge>
+              <p className="text-xs text-stone-500 leading-relaxed">{ROLE_DESCRIPTIONS[opt.value]}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Staff List */}
+      <div className="bg-white rounded-2xl border border-stone-200 shadow-sm overflow-hidden">
+
+        {isLoading && (
+          <div className="flex items-center justify-center py-16 text-stone-400">
+            <Loader2 className="w-6 h-6 animate-spin mr-2" />
+            <span className="text-sm">Loading staff members...</span>
+          </div>
+        )}
+
+        {!isLoading && staffList.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-16 text-stone-400">
+            <ShieldCheck className="w-10 h-10 mb-3 opacity-30" />
+            <p className="text-sm font-medium">No staff members found.</p>
+            <p className="text-xs mt-1">Only Moderator and Member accounts appear here.</p>
+          </div>
+        )}
+
+        {!isLoading && staffList.length > 0 && (
+          <div className="divide-y divide-stone-100">
+            {/* Table Header */}
+            <div className="grid grid-cols-12 px-6 py-3 bg-stone-50 border-b border-stone-200">
+              <span className="col-span-5 text-[10px] font-bold uppercase tracking-widest text-stone-500">Staff Member</span>
+              <span className="col-span-3 text-[10px] font-bold uppercase tracking-widest text-stone-500 hidden sm:block">Last Login</span>
+              <span className="col-span-4 text-[10px] font-bold uppercase tracking-widest text-stone-500">Role</span>
+            </div>
+
+            {staffList.map(member => (
+              <div
+                key={member.id}
+                className="grid grid-cols-12 items-center px-6 py-4 hover:bg-stone-50/60 transition-colors"
+              >
+                {/* Name + Email */}
+                <div className="col-span-5 min-w-0">
+                  <p className="text-sm font-semibold text-stone-800 truncate">
+                    {member.last_name}, {member.first_name}
+                  </p>
+                  <div className="flex items-center gap-1 mt-0.5">
+                    <Mail size={11} className="text-stone-400 shrink-0" />
+                    <p className="text-xs text-stone-400 truncate">{member.email}</p>
+                  </div>
+                </div>
+
+                {/* Last Login */}
+                <div className="col-span-3 hidden sm:flex items-center gap-1.5 text-xs text-stone-500">
+                  <Clock size={12} className="text-stone-400 shrink-0" />
+                  {formatLastLogin(member.last_login)}
+                </div>
+
+                {/* Role Select */}
+                <div className="col-span-4">
+                  <Select
+                    value={member.role}
+                    onValueChange={(newRole) => handleRoleSelectChange(member, newRole)}
+                  >
+                    <SelectTrigger className="h-9 text-sm border-stone-200 bg-white focus:ring-amber-500/20 focus:border-amber-500">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_OPTIONS.map(opt => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Confirmation Dialog */}
+      <Dialog open={!!pendingChange} onOpenChange={(open) => { if (!open) setPendingChange(null); }}>
+        <DialogContent className="max-w-md rounded-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold text-stone-900">Confirm Role Change</DialogTitle>
+            <DialogDescription className="text-stone-500 text-sm mt-1">
+              You are about to change{" "}
+              <span className="font-semibold text-stone-800">
+                {pendingChange?.member.first_name} {pendingChange?.member.last_name}
+              </span>
+              {"'s"} role from{" "}
+              <Badge className={`inline-flex border text-xs ${ROLE_STYLES[pendingChange?.member.role ?? "MEMBER"]}`}>
+                {pendingChange?.member.role}
+              </Badge>
+              {" "}to{" "}
+              <Badge className={`inline-flex border text-xs ${ROLE_STYLES[pendingChange?.newRole ?? "MEMBER"]}`}>
+                {pendingChange?.newRole}
+              </Badge>
+              .
+            </DialogDescription>
+          </DialogHeader>
+
+          {pendingChange && (
+            <div className="mt-2 p-3 bg-amber-50 border border-amber-100 rounded-xl text-xs text-amber-800 leading-relaxed">
+              <strong>New permissions:</strong> {ROLE_DESCRIPTIONS[pendingChange.newRole]}
+            </div>
+          )}
+
+          <DialogFooter className="mt-4 flex gap-2">
+            <Button
+              variant="outline"
+              className="flex-1 border-stone-200"
+              onClick={() => setPendingChange(null)}
+              disabled={isUpdating}
+            >
+              Cancel
+            </Button>
+            <Button
+              className="flex-1 bg-amber-700 hover:bg-amber-800 text-white"
+              onClick={confirmRoleChange}
+              disabled={isUpdating}
+            >
+              {isUpdating
+                ? <><Loader2 className="w-4 h-4 animate-spin mr-2" /> Saving...</>
+                : "Confirm Change"
+              }
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/admin/tabs/SchedulesTab.tsx
+++ b/src/components/admin/tabs/SchedulesTab.tsx
@@ -18,9 +18,11 @@ import toast from "react-hot-toast";
 interface ScheduleProp {
     schedules: Schedule[];
     fetchSchedules: () => Promise<void>;
+    userRole: string;
 }
 
-export function SchedulesTab({ schedules, fetchSchedules }: ScheduleProp) {
+export function SchedulesTab({ schedules, fetchSchedules, userRole }: ScheduleProp) {
+  const canCreateSchedule = userRole === 'ADMINISTRATOR';
 
   // Input states
   const [newDateInput, setNewDateInput] = useState("");
@@ -229,13 +231,15 @@ export function SchedulesTab({ schedules, fetchSchedules }: ScheduleProp) {
                 <p className="text-stone-500 text-sm mt-1">Manage dates, capacities, and monitor student attendance per session.</p>
             </div>
             
-            {/* Modal for adding a new schedule date */}
+            {/* Modal for adding a new schedule date — ADMINISTRATOR only */}
             <Dialog open={isAddDateOpen} onOpenChange={setIsAddDateOpen}>
-                <DialogTrigger asChild>
-                    <Button className="bg-amber-900 hover:bg-amber-800 shadow-lg">
-                        <Plus className="mr-2 h-4 w-4" /> Add Date
-                    </Button>
-                </DialogTrigger>
+                {canCreateSchedule && (
+                    <DialogTrigger asChild>
+                        <Button className="bg-amber-900 hover:bg-amber-800 shadow-lg">
+                            <Plus className="mr-2 h-4 w-4" /> Add Date
+                        </Button>
+                    </DialogTrigger>
+                )}
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Open New Schedule</DialogTitle>

--- a/src/hooks/useSidebar.ts
+++ b/src/hooks/useSidebar.ts
@@ -1,23 +1,32 @@
 import { useMemo } from "react";
 
 export function useSidebar(user: any) {
-  
-  // kani na check kung admin ba ang ga login (case-insensitive para sure)
-  const isAdmin = useMemo(() => {
-    if (!user || !user.role) return false;
-    const role = user.role.toLowerCase();
-    return role === 'admin' || role === 'administrator';
+
+  const role = useMemo(() => {
+    if (!user || !user.role) return 'MEMBER';
+    return String(user.role).toUpperCase();
   }, [user]);
 
-  // fallback para dli ma blanko ang ubos kung wala silay gi set nga position
-  const displayPosition = user?.position || (isAdmin ? "Administrator" : "Staff Member");
+  const isAdmin = role === 'ADMINISTRATOR';
+  const isModerator = role === 'MODERATOR';
+  const isMember = role === 'MEMBER';
 
-  // pwede kaayo nato i-derive diri daan ang initials sa avatar para limpyo sa UI
+  // Tabs visible to ADMINISTRATOR and MODERATOR
+  const canAccessVerification = isAdmin || isModerator;
+  const canAccessSchedules = isAdmin || isModerator;
+
+  // Tab visible to ADMINISTRATOR only
+  const canManageRoles = isAdmin;
+
+  const displayPosition = user?.position || (
+    isAdmin ? "Administrator" : isModerator ? "Moderator" : "Staff Member"
+  );
+
   const getInitials = (name: string) => {
     if (!name) return isAdmin ? 'AD' : 'ST';
     const parts = name.split(' ');
     if (parts.length > 1) {
-        return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+      return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
     }
     return name.substring(0, 2).toUpperCase();
   };
@@ -25,7 +34,13 @@ export function useSidebar(user: any) {
   const userInitials = useMemo(() => getInitials(user?.name), [user?.name, isAdmin]);
 
   return {
+    role,
     isAdmin,
+    isModerator,
+    isMember,
+    canAccessVerification,
+    canAccessSchedules,
+    canManageRoles,
     displayPosition,
     userInitials
   };


### PR DESCRIPTION
## Summary

- Updated useSidebar.ts to expose granular flags: isAdmin, isModerator, isMember, canAccessVerification, canAccessSchedules, canManageRoles
- Updated AdminSidebar.tsx — Verification Queue, Graduate Verification, and Schedules are now visible to ADMINISTRATOR + MODERATOR; new "Manage Staffs" nav item is ADMINISTRATOR-only
- Updated MasterlistTab.tsx — accepts userRole prop; Export Excel and Send OTP buttons hidden for MEMBER; Delete student button hidden for MODERATOR and MEMBER
- Updated SchedulesTab.tsx — accepts userRole prop; Add Date button hidden for MODERATOR
Added fetchStaffList() and updateAdminRole() to adminService.tsx
- Added new RolesTab.tsx — multi-select role editor with a sticky unsaved-changes bar, a confirmation dialog showing a full OldRole → NewRole diff list per staff member, and a password gate (POST /api/admin/verify-password) before changes are applied in parallel
- Updated dashboard/page.tsx — derives userRole from staffUser.role, passes it to MasterlistTab and SchedulesTab, renders RolesTab for the roles tab