### PR TITLE
feat: logout upon successful pass change

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -267,7 +267,7 @@ export default function AdminDashboard() {
             {/* 4. OTHER ADMIN TABS */}
             {activeTab === 'masterlist' && <MasterlistTab {...masterlistProps} userRole={userRole} />}
             {activeTab === 'slots' && <SchedulesTab schedules={schedules} fetchSchedules={fetchSchedules} userRole={userRole} />}
-            {activeTab === "profile" && <ProfileTab user={staffUser} setUser={setStaffUser} />}
+            {activeTab === "profile" && <ProfileTab user={staffUser} setUser={setStaffUser} onLogout={onLogout} />}
 
             {/* 5. ROLE MANAGEMENT — ADMINISTRATOR only */}
             {activeTab === 'roles' && <RolesTab staffUser={staffUser} />}

--- a/src/components/admin/tabs/ProfileTab.tsx
+++ b/src/components/admin/tabs/ProfileTab.tsx
@@ -14,9 +14,10 @@ import { Admin } from "@/types";
 interface ProfileTabProps {
     user: Admin | null;
     setUser: (user: Admin | null) => void;
+    onLogout: () => void;
 }
 
-export function ProfileTab({ user }: ProfileTabProps) {
+export function ProfileTab({ user, onLogout }: ProfileTabProps) {
 
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
   const [currentPassword, setCurrentPassword] = useState("");
@@ -65,7 +66,7 @@ export function ProfileTab({ user }: ProfileTabProps) {
               return;
           }
           setPasswordSuccess("Password updated successfully!");
-          setTimeout(() => handleCloseModal(), 2000);
+          setTimeout(() => { handleCloseModal(); onLogout(); }, 2000);
       } catch {
           setPasswordError("An error occurred. Please try again.");
       } finally {


### PR DESCRIPTION
This pull request enhances the admin profile management experience by ensuring that after a successful password update, the user is automatically logged out. This improves security and aligns with best practices. The main changes include passing an `onLogout` handler through the component hierarchy and invoking it after a password change.

**Profile logout after password change:**

* [`src/app/admin/dashboard/page.tsx`](diffhunk://#diff-fee31ffecbe27abca2f678e7b0218dae73d5fbc7d10500dfcbb96f85248c1541L270-R270): Passes the `onLogout` callback to the `ProfileTab` component to enable logout functionality after password updates.
* [`src/components/admin/tabs/ProfileTab.tsx`](diffhunk://#diff-6b0cbb8289a8a9b4ae112bd33de2aa5a58cc7a5814c19a5da1420dd469fe7c6bR17-R20): Updates the `ProfileTabProps` interface and component to accept and use the `onLogout` prop.
* [`src/components/admin/tabs/ProfileTab.tsx`](diffhunk://#diff-6b0cbb8289a8a9b4ae112bd33de2aa5a58cc7a5814c19a5da1420dd469fe7c6bL68-R69): Calls `onLogout` after closing the password modal when the password is successfully updated, ensuring the user is logged out.