### PR TITLE
Extract reusable custom hooks

### DIFF
--- a/src/app/student/dashboard/page.tsx
+++ b/src/app/student/dashboard/page.tsx
@@ -17,15 +17,16 @@ import toast from "react-hot-toast";
 import { Booking, Schedule } from "@/types/index";
 import * as studentService from "@/app/student/studentService";
 import { Student } from "@/types";
+import { useModalState } from "@/hooks/useModalState";
 
 export default function StudentDashboard() {
   const router = useRouter(); 
   const [user, setUser] = useState<Student | null>(null);
   const [schedule, setSchedule] = useState<Schedule[]>([]);
   const [booking, setBooking] = useState<Booking>();
-  const [showPreview, setShowPreview] = useState(false);
-  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const previewModal = useModalState();
+  const logoutModal = useModalState();
 
   const fetchStudent = useCallback(async () => {
     try {
@@ -113,8 +114,8 @@ export default function StudentDashboard() {
     );
   }
 
-  if (showPreview) {
-    return <YearbookPreview user={user} onClose={() => setShowPreview(false)} />;
+  if (previewModal.isOpen) {
+    return <YearbookPreview user={user} onClose={previewModal.close} />;
   }
 
   return (
@@ -122,7 +123,7 @@ export default function StudentDashboard() {
       
       <StudentHeader 
         user={{ fname: user.first_name, idNumber: user.student_number, photoUrl: user.studentDetail.photo_url ?? ""}}
-        onLogout={() => setShowLogoutConfirm(true)} 
+        onLogout={logoutModal.open}
       />
 
       <main className="max-w-5xl mx-auto p-6 space-y-8">
@@ -153,7 +154,7 @@ export default function StudentDashboard() {
               idNumber={user.student_number}
               course={user.course}
               photoUrl={user.studentDetail.photo_url ?? ""}
-              onCheckEntry={() => setShowPreview(true)} 
+              onCheckEntry={previewModal.open}
             />
           </div>
 
@@ -181,7 +182,7 @@ export default function StudentDashboard() {
       </main>
 
       {/* --- LOGOUT CONFIRMATION MODAL --- */}
-      {showLogoutConfirm && (
+      {logoutModal.isOpen && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4 animate-in fade-in duration-200">
           <div className="bg-white rounded-2xl shadow-2xl max-w-sm w-full p-6 text-center animate-in zoom-in-95 duration-200">
             <div className="w-16 h-16 bg-red-100 text-red-600 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -193,7 +194,7 @@ export default function StudentDashboard() {
             </p>
             <div className="flex gap-3 w-full">
               <button 
-                onClick={() => setShowLogoutConfirm(false)}
+                onClick={logoutModal.close}
                 disabled={isLoggingOut}
                 className="flex-1 py-2.5 rounded-lg border border-stone-200 text-stone-600 font-medium hover:bg-stone-50 transition-colors disabled:opacity-50"
               >

--- a/src/components/student/dashboard/BookingWidget.tsx
+++ b/src/components/student/dashboard/BookingWidget.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Booking, Schedule } from "@/types";
+import { useModalState } from "@/hooks/useModalState";
 
 interface BookingWidgetProps {
   bookingList: Schedule[], 
@@ -17,8 +18,8 @@ interface BookingWidgetProps {
 };
 
 export function BookingWidget({ bookingList, booking, idNumber, onBook }: BookingWidgetProps) {
-  const [isBookingModalOpen, setIsBookingModalOpen] = useState(false);
-  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+  const bookingModal = useModalState();
+  const confirmationModal = useModalState();
   const [selectedBookingId, setSelectedBookingId] = useState<number>(0);
   const [selectedDate, setSelectedDate] = useState("");
   const [selectedSession, setSelectedSession] = useState<"AM" | "PM" | "">("");
@@ -36,8 +37,8 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
         setIsSubmitting(true);
         try {
           await onBook(selectedBookingId, selectedSession);
-          setIsConfirmDialogOpen(false);
-          setIsBookingModalOpen(false);
+          confirmationModal.close();
+          bookingModal.close();
         } catch (error) {
             console.error("Booking failed:", error);
         } finally {
@@ -51,7 +52,7 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
     setSelectedBookingId(0);
     setSelectedDate("");
     setSelectedSession("");
-    setIsBookingModalOpen(true);
+    bookingModal.open();
   };
 
   return (
@@ -117,12 +118,12 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
                  <p className="text-sm text-stone-500 max-w-xs mx-auto">Slots are filling up fast. Book now to secure your spot.</p>
              </div>
              
-             <Button className="bg-amber-900 hover:bg-amber-800" onClick={() => setIsBookingModalOpen(true)}>Book a Slot Now</Button>
+             <Button className="bg-amber-900 hover:bg-amber-800" onClick={bookingModal.open}>Book a Slot Now</Button>
           </div>
         )}
 
         {/* MODALS MOVED OUTSIDE CONDITIONAL RENDER TO RE-USE THEM */}
-        <Dialog open={isBookingModalOpen} onOpenChange={setIsBookingModalOpen}>
+        <Dialog open={bookingModal.isOpen} onOpenChange={bookingModal.setIsOpen}>
             <DialogContent className="max-w-2xl">
                 <DialogHeader>
                     <DialogTitle>{booking ? "Change Schedule" : "Select Pictorial Schedule"}</DialogTitle>
@@ -174,14 +175,14 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
                     <div className="text-xs text-stone-500 text-center sm:text-left">
                         {selectedDate ? <span>Selected: <strong>{new Date(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })} ({selectedSession})</strong></span> : "Please select a slot"}
                     </div>
-                    <Button onClick={() => setIsConfirmDialogOpen(true)} disabled={!selectedDate || !selectedSession} className="bg-amber-900 w-full sm:w-auto">
+                    <Button onClick={confirmationModal.open} disabled={!selectedDate || !selectedSession} className="bg-amber-900 w-full sm:w-auto">
                         {booking ? "Confirm New Schedule" : "Submit Schedule"}
                     </Button>
                 </DialogFooter>
             </DialogContent>
          </Dialog>
 
-         <Dialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
+         <Dialog open={confirmationModal.isOpen} onOpenChange={confirmationModal.setIsOpen}>
             <DialogContent className="max-w-md">
                 <DialogHeader>
                     <DialogTitle className="flex items-center gap-2 text-red-600"><AlertTriangle className="w-5 h-5" /> Final Confirmation</DialogTitle>
@@ -193,7 +194,7 @@ export function BookingWidget({ bookingList, booking, idNumber, onBook }: Bookin
                     </DialogDescription>
                 </DialogHeader>
                 <DialogFooter>
-                    <Button variant="outline" onClick={() => setIsConfirmDialogOpen(false)} disabled={isSubmitting}>Cancel</Button>
+                    <Button variant="outline" onClick={confirmationModal.close} disabled={isSubmitting}>Cancel</Button>
                     <Button onClick={handleConfirm} disabled={isSubmitting} className="bg-red-600 hover:bg-red-700 text-white flex items-center gap-2">
                         {isSubmitting && <Loader2 className="w-4 h-4 animate-spin" />}
                         {isSubmitting ? "Booking..." : "Yes, Finalize"}

--- a/src/hooks/useModalState.ts
+++ b/src/hooks/useModalState.ts
@@ -1,0 +1,17 @@
+import { useCallback, useState } from "react";
+
+export function useModalState(initialOpen = false) {
+  const [isOpen, setIsOpen] = useState(initialOpen);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((current) => !current), []);
+
+  return {
+    isOpen,
+    setIsOpen,
+    open,
+    close,
+    toggle,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable `useModalState` hook
- apply shared modal state behavior to the student dashboard and booking widget
- preserve existing modal UI behavior

## Validation
- `npm run build` passed
- `npm run lint` run; remaining findings are pre-existing lint debt

## Review note
This is an independent draft PR targeting `main`. Do not merge until the senior developer has reviewed the full refactor branch set.