### PR TITLE
Preview standardized thesis titles

### DIFF
--- a/src/components/admin/tabs/GraduateReviewTab.tsx
+++ b/src/components/admin/tabs/GraduateReviewTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useMemo, useState, useRef } from "react";
 import Image from "next/image";
 import { Search, Edit3, Save, Clock, MapPin, Home, Phone, Mail, GraduationCap, User, Image as ImageIcon, Upload, FolderOpen, X, CheckCircle2, BookOpen, Building2, ChevronLeft, ChevronRight, Loader2, Camera, FileText, type LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/alert-dialog";
 
 import { useGraduateReview } from "@/hooks/useGraduateReview"; 
+import { getThesisTitleStandardization } from "@/utils/thesisTitle";
 
 interface VerificationTabProps {
   staffUser: any;
@@ -94,6 +95,14 @@ export function GraduateReviewTab({ staffUser, selectedStudent, setSelectedStude
   const [showInfoSaveConfirm, setShowInfoSaveConfirm] = useState(false);
   const [showPhotoSaveConfirm, setShowPhotoSaveConfirm] = useState(false);
   const [enlargedImage, setEnlargedImage] = useState<string | null>(null);
+  const [thesisDraft, setThesisDraft] = useState("");
+  const thesisTitleStandardization = useMemo(() => getThesisTitleStandardization(thesisDraft), [thesisDraft]);
+
+  useEffect(() => {
+    if (isEditing) {
+      setThesisDraft(selectedStudent?.thesis_title || "");
+    }
+  }, [isEditing, selectedStudent?.id, selectedStudent?.thesis_title]);
 
   const onSaveInfoClick = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -278,7 +287,26 @@ export function GraduateReviewTab({ staffUser, selectedStudent, setSelectedStude
                                         <TabsContent value="academic" className="space-y-4 sm:space-y-5 bg-white p-4 sm:p-6 rounded-xl border border-stone-200 shadow-sm">
                                             <div className="space-y-1.5"><Label className="text-stone-500 font-bold text-[10px] uppercase">Course</Label><Input name="course" defaultValue={selectedStudent.course} className="h-9 text-sm"/></div>
                                             <div className="space-y-1.5"><Label className="text-stone-500 font-bold text-[10px] uppercase">Major</Label><Input name="major" defaultValue={selectedStudent.major} className="h-9 text-sm"/></div>
-                                            <div className="space-y-1.5"><Label className="text-stone-500 font-bold text-[10px] uppercase">Thesis Title</Label><Input name="thesis" defaultValue={selectedStudent.thesis_title} className="h-9 text-sm"/></div>
+                                            <div className="space-y-1.5">
+                                                <Label className="text-stone-500 font-bold text-[10px] uppercase">Thesis Title</Label>
+                                                <Input name="thesis" value={thesisDraft} onChange={(e) => setThesisDraft(e.target.value)} className="h-9 text-sm"/>
+                                                {thesisTitleStandardization.isChanged && (
+                                                    <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-xs text-amber-950 space-y-2">
+                                                        <p className="font-bold uppercase tracking-wide text-[10px] text-amber-700">Standardized APA title preview</p>
+                                                        <p><span className="font-semibold">Original:</span> {thesisTitleStandardization.original}</p>
+                                                        <p><span className="font-semibold">Standardized:</span> {thesisTitleStandardization.standardized}</p>
+                                                        <Button
+                                                            type="button"
+                                                            variant="outline"
+                                                            size="sm"
+                                                            className="h-8 border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
+                                                            onClick={() => setThesisDraft(thesisTitleStandardization.standardized)}
+                                                        >
+                                                            Use Standardized Title
+                                                        </Button>
+                                                    </div>
+                                                )}
+                                            </div>
                                         </TabsContent>
 
                                         <TabsContent value="contact" className="space-y-4 sm:space-y-5 bg-white p-4 sm:p-6 rounded-xl border border-stone-200 shadow-sm">

--- a/src/components/forms/RegistrationWizard.tsx
+++ b/src/components/forms/RegistrationWizard.tsx
@@ -20,6 +20,7 @@ import { FamilyStep } from "@/components/registration/FamilyStep";
 import { ReviewStep } from "@/components/registration/ReviewStep";
 import { PrivacyStep } from "@/components/registration/PrivacyStep";
 import toast from "react-hot-toast";
+import { formatApaThesisTitle } from "@/utils/thesisTitle";
 
 const steps = [
   { id: 1, name: "Personal", title: "Personal Information" },
@@ -144,6 +145,7 @@ export default function RegistrationWizard() {
   const [email, setEmail] = useState("");
   const [umEmail, setUmEmail] = useState(""); 
   const [hasUmEmailAccess, setHasUmEmailAccess] = useState(true);
+  const standardizedThesisTitle = useMemo(() => formatApaThesisTitle(thesisTitle), [thesisTitle]);
 
   // --- STATE: Family ---
   const [useGuardian, setUseGuardian] = useState(false);
@@ -239,7 +241,7 @@ export default function RegistrationWizard() {
         nickname: nickname, 
         birthdate: bdate, 
         contact_num: contactNum, 
-        academics: { department: selectedDepartment, course: selectedCourse, major: selectedMajor, thesis: thesisTitle }, 
+        academics: { department: selectedDepartment, course: selectedCourse, major: selectedMajor, thesis: standardizedThesisTitle },
         ...relation, 
         province: provinceName, 
         city: cityName, 
@@ -326,7 +328,7 @@ export default function RegistrationWizard() {
                     {/* FIXED: Included FamilyStep (Step 4) */}
                     {currentStep === 4 && <FamilyStep useGuardian={useGuardian} setUseGuardian={setUseGuardian} guardianLname={guardianLname} setGuardianLname={setGuardianLname} guardianTitle={guardianTitle} setGuardianTitle={setGuardianTitle} guardianFname={guardianFname} setGuardianFname={setGuardianFname} guardianRel={guardianRel} setGuardianRel={setGuardianRel} fatherLname={fatherLname} setFatherLname={setFatherLname} fatherTitle={fatherTitle} setFatherTitle={setFatherTitle} fatherFname={fatherFname} setFatherFname={setFatherFname} fatherMname={fatherMname} setFatherMname={setFatherMname} fatherSuffix={fatherSuffix} setFatherSuffix={setFatherSuffix} motherLname={motherLname} setMotherLname={setMotherLname} motherTitle={motherTitle} setMotherTitle={setMotherTitle} motherFname={motherFname} setMotherFname={setMotherFname} motherMname={motherMname} setMotherMname={setMotherMname} />}
                     
-                    {currentStep === 5 && <ReviewStep idNumber={idNumber} fname={fname} mname={mname} lname={lname} suffix={suffix} nickname={nickname} formattedBirthdate={formattedBirthdate} barangayName={barangayName} cityName={cityName} provinceName={provinceName} selectedDepartment={selectedDepartment} selectedCourse={selectedCourse} selectedMajor={selectedMajor} thesisTitle={thesisTitle} umEmail={hasUmEmailAccess ? umEmail : "N/A (No Access)"} contactNum={contactNum} email={email} useGuardian={useGuardian} guardianTitle={guardianTitle} guardianFname={guardianFname} guardianLname={guardianLname} guardianRel={guardianRel} fatherTitle={fatherTitle} fatherFname={fatherFname} fatherMname={fatherMname} fatherLname={fatherLname} fatherSuffix={fatherSuffix} motherTitle={motherTitle} motherFname={motherFname} motherMname={motherMname} motherLname={motherLname} reviewConfirmed={reviewConfirmed} setReviewConfirmed={setReviewConfirmed} />}
+                    {currentStep === 5 && <ReviewStep idNumber={idNumber} fname={fname} mname={mname} lname={lname} suffix={suffix} nickname={nickname} formattedBirthdate={formattedBirthdate} barangayName={barangayName} cityName={cityName} provinceName={provinceName} selectedDepartment={selectedDepartment} selectedCourse={selectedCourse} selectedMajor={selectedMajor} thesisTitle={thesisTitle} standardizedThesisTitle={standardizedThesisTitle} umEmail={hasUmEmailAccess ? umEmail : "N/A (No Access)"} contactNum={contactNum} email={email} useGuardian={useGuardian} guardianTitle={guardianTitle} guardianFname={guardianFname} guardianLname={guardianLname} guardianRel={guardianRel} fatherTitle={fatherTitle} fatherFname={fatherFname} fatherMname={fatherMname} fatherLname={fatherLname} fatherSuffix={fatherSuffix} motherTitle={motherTitle} motherFname={motherFname} motherMname={motherMname} motherLname={motherLname} reviewConfirmed={reviewConfirmed} setReviewConfirmed={setReviewConfirmed} />}
                     {currentStep === 6 && <PrivacyStep privacyAgreed={privacyAgreed} setPrivacyAgreed={setPrivacyAgreed} />}
                     
                     </motion.div>

--- a/src/components/registration/AcademicStep.tsx
+++ b/src/components/registration/AcademicStep.tsx
@@ -1,10 +1,12 @@
 // src/components/registration/AcademicStep.tsx
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox"; 
 import { departmentOptions } from "@/constants/registration";
 import { MailWarning, AlertCircle, CheckCircle2 } from "lucide-react"; 
+import { getThesisTitleStandardization } from "@/utils/thesisTitle";
 
 export const AcademicStep = ({ 
     selectedDepartment, handleDepartmentChange, 
@@ -16,6 +18,7 @@ export const AcademicStep = ({
     umEmail, setUmEmail,
     hasUmEmailAccess, setHasUmEmailAccess 
 }: any) => {
+  const thesisTitleStandardization = getThesisTitleStandardization(thesisTitle);
 
   // Simple Regex to check if email format is valid (has @ and domain)
   const isValidEmail = (emailStr: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailStr);
@@ -55,6 +58,27 @@ export const AcademicStep = ({
       <div className="space-y-2">
           <Label>Thesis / Capstone Title <span className="text-red-500">*</span></Label>
           <Input value={thesisTitle} onChange={e => setThesisTitle(e.target.value)} placeholder="Enter complete title of your Thesis or Capstone Project" className="h-11" />
+          {thesisTitleStandardization.isChanged && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-xs text-amber-950 space-y-3">
+              <div>
+                <p className="font-bold uppercase tracking-wide text-[10px] text-amber-700">Standardized APA title preview</p>
+                <p className="mt-1 text-stone-600">This is how the title will be saved unless an admin reviews an exception.</p>
+              </div>
+              <div className="space-y-1">
+                <p><span className="font-bold">Original:</span> {thesisTitleStandardization.original}</p>
+                <p><span className="font-bold">Standardized:</span> {thesisTitleStandardization.standardized}</p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
+                onClick={() => setThesisTitle(thesisTitleStandardization.standardized)}
+              >
+                Use Standardized Title
+              </Button>
+            </div>
+          )}
       </div>
 
       <div className="h-px bg-gray-200 my-2"></div>

--- a/src/components/registration/ReviewStep.tsx
+++ b/src/components/registration/ReviewStep.tsx
@@ -3,7 +3,11 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox"; 
 import { UserCircle, ClipboardCheck, MapPin, GraduationCap, Users, Mail, Phone, Calendar, CreditCard } from "lucide-react";
 
-export const ReviewStep = ({ idNumber, fname, mname, lname, suffix, nickname, formattedBirthdate, barangayName, cityName, provinceName, selectedDepartment, selectedCourse, selectedMajor, thesisTitle, umEmail, contactNum, email, useGuardian, guardianTitle, guardianFname, guardianLname, guardianRel, fatherTitle, fatherFname, fatherMname, fatherLname, fatherSuffix, motherTitle, motherFname, motherMname, motherLname, reviewConfirmed, setReviewConfirmed }: any) => (
+export const ReviewStep = ({ idNumber, fname, mname, lname, suffix, nickname, formattedBirthdate, barangayName, cityName, provinceName, selectedDepartment, selectedCourse, selectedMajor, thesisTitle, standardizedThesisTitle, umEmail, contactNum, email, useGuardian, guardianTitle, guardianFname, guardianLname, guardianRel, fatherTitle, fatherFname, fatherMname, fatherLname, fatherSuffix, motherTitle, motherFname, motherMname, motherLname, reviewConfirmed, setReviewConfirmed }: any) => {
+  const finalThesisTitle = standardizedThesisTitle || thesisTitle;
+  const titleWasStandardized = Boolean(thesisTitle && finalThesisTitle && thesisTitle.trim() !== finalThesisTitle);
+
+  return (
   <div className="space-y-8 animate-in fade-in duration-500">
     <div className="bg-stone-50/80 border border-stone-200 rounded-xl p-6 shadow-sm">
         <div className="flex items-center gap-3 mb-6 pb-4 border-b border-stone-200">
@@ -28,7 +32,17 @@ export const ReviewStep = ({ idNumber, fname, mname, lname, suffix, nickname, fo
             <h4 className="flex items-center gap-2 text-sm font-bold text-amber-900 uppercase tracking-wider"><GraduationCap size={16} /> Academic Profile</h4>
             <div className="bg-white p-4 rounded-lg border border-stone-100 shadow-sm space-y-4">
             <div><span className="block text-[10px] uppercase tracking-wider text-stone-500 font-bold mb-1">Department</span><span className="text-stone-900 font-bold block mb-2">{selectedDepartment}</span><span className="block text-[10px] uppercase tracking-wider text-stone-500 font-bold mb-1">Course & Major</span><span className="text-stone-900 font-bold block">{selectedCourse}</span>{selectedMajor !== "N/A" && <span className="text-amber-700 text-sm font-medium block mt-1">{selectedMajor}</span>}</div>
-            <div className="pt-2 border-t border-stone-100 mt-2"><span className="block text-[10px] uppercase tracking-wider text-stone-500 font-bold mb-1">Thesis / Capstone Title</span><span className="text-stone-900 font-medium italic">"{thesisTitle}"</span></div>
+            <div className="pt-2 border-t border-stone-100 mt-2 space-y-2">
+                <span className="block text-[10px] uppercase tracking-wider text-stone-500 font-bold mb-1">Thesis / Capstone Title</span>
+                <span className="text-stone-900 font-medium italic">"{finalThesisTitle}"</span>
+                {titleWasStandardized && (
+                    <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-950 space-y-1">
+                        <p className="font-bold">APA title format will be applied before submission.</p>
+                        <p><span className="font-semibold">Originally entered:</span> "{thesisTitle.trim()}"</p>
+                        <p><span className="font-semibold">Saved title:</span> "{finalThesisTitle}"</p>
+                    </div>
+                )}
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2 border-t border-stone-100">
                 <div><span className="block text-[10px] uppercase tracking-wider text-stone-500 font-bold mb-1">UM Student Email</span><div className="flex items-center gap-2 text-blue-700 font-medium break-all"><Mail size={14}/> {umEmail || "-"}</div></div>
                 <div><span className="block text-[10px] uppercase tracking-wider text-stone-500 font-bold mb-1">Contact Number</span><div className="flex items-center gap-2 text-stone-900 font-medium"><Phone size={14} className="text-amber-600"/> {contactNum || "-"}</div></div>
@@ -56,4 +70,5 @@ export const ReviewStep = ({ idNumber, fname, mname, lname, suffix, nickname, fo
         <Label htmlFor="confirm-review" className="text-sm font-medium leading-snug cursor-pointer text-stone-700">I hereby confirm that the details shown above are true, correct, and free from errors.</Label>
     </div>
   </div>
-);
+  );
+};

--- a/src/hooks/useGraduateReview.ts
+++ b/src/hooks/useGraduateReview.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect } from "react";
 import toast from "react-hot-toast";
 import { Student } from "@/types";
+import { formatApaThesisTitle } from "@/utils/thesisTitle";
 
 import * as adminService from "../app/admin/adminService";
 
@@ -100,8 +101,14 @@ export function useGraduateReview(staffUser: any, selectedStudent: any, setSelec
         continue;
       }
 
-      const submittedValue = normalizeValue(formData.get(formKey));
-      const currentValue = normalizeValue(getCurrentValue(dataKey));
+      const submittedValue =
+        dataKey === "thesis"
+          ? formatApaThesisTitle(formData.get(formKey))
+          : normalizeValue(formData.get(formKey));
+      const currentValue =
+        dataKey === "thesis"
+          ? normalizeValue(selectedStudent?.thesis_title)
+          : normalizeValue(getCurrentValue(dataKey));
       const category = fieldCategories[dataKey];
 
       if (!category || submittedValue === currentValue) {

--- a/src/utils/thesisTitle.ts
+++ b/src/utils/thesisTitle.ts
@@ -1,0 +1,155 @@
+const MINOR_WORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "as",
+  "at",
+  "but",
+  "by",
+  "for",
+  "if",
+  "in",
+  "nor",
+  "of",
+  "on",
+  "or",
+  "per",
+  "so",
+  "the",
+  "to",
+  "up",
+  "via",
+  "yet",
+]);
+
+const INTENTIONAL_CASE = new Map([
+  ["ai", "AI"],
+  ["api", "API"],
+  ["covid-19", "COVID-19"],
+  ["css", "CSS"],
+  ["ehealth", "eHealth"],
+  ["elearning", "eLearning"],
+  ["html", "HTML"],
+  ["ict", "ICT"],
+  ["iot", "IoT"],
+  ["it", "IT"],
+  ["lgbtq+", "LGBTQ+"],
+  ["stem", "STEM"],
+  ["tvl", "TVL"],
+  ["ui", "UI"],
+  ["um", "UM"],
+]);
+
+const PROTECTED_PHRASES = [
+  "City of Davao",
+  "Davao de Oro",
+  "Davao del Norte",
+  "Davao del Sur",
+  "Davao Occidental",
+  "Davao Oriental",
+  "Island Garden City of Samal",
+  "Santo Tomas",
+  "University of Mindanao",
+];
+
+const WORD_PART_PATTERN = /^([^A-Za-z0-9]*)(.*?)([^A-Za-z0-9+]*?)$/;
+const SUBTITLE_SEPARATOR_PATTERN = /[:?!\u2013\u2014]$/;
+
+function capitalizeWord(word: string) {
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+function hasIntentionalMixedCase(word: string) {
+  return (
+    /[a-z]/.test(word) &&
+    /[A-Z]/.test(word) &&
+    !/^[A-Z][a-z]+(?:'[a-z]+)?$/.test(word)
+  );
+}
+
+function formatWordCore(core: string, forceCapitalize: boolean, isLastWord: boolean) {
+  const configuredCase = INTENTIONAL_CASE.get(core.toLowerCase());
+  if (configuredCase) {
+    return configuredCase;
+  }
+
+  if (hasIntentionalMixedCase(core)) {
+    return core;
+  }
+
+  return core
+    .split("-")
+    .map((part) => {
+      if (!part) {
+        return part;
+      }
+
+      const partConfiguredCase = INTENTIONAL_CASE.get(part.toLowerCase());
+      if (partConfiguredCase) {
+        return partConfiguredCase;
+      }
+
+      if (hasIntentionalMixedCase(part)) {
+        return part;
+      }
+
+      const shouldCapitalize =
+        forceCapitalize ||
+        isLastWord ||
+        !MINOR_WORDS.has(part.toLowerCase());
+
+      return shouldCapitalize ? capitalizeWord(part) : part.toLowerCase();
+    })
+    .join("-");
+}
+
+function restoreProtectedPhrases(title: string) {
+  return PROTECTED_PHRASES.reduce((result, phrase) => {
+    const escapedPhrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return result.replace(new RegExp(escapedPhrase, "gi"), phrase);
+  }, title);
+}
+
+export function formatApaThesisTitle(value: unknown) {
+  const normalized =
+    typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+
+  if (!normalized) {
+    return "";
+  }
+
+  const words = normalized.split(" ");
+  let capitalizeNext = true;
+
+  const formatted = words.map((word, index) => {
+    const match = word.match(WORD_PART_PATTERN);
+    if (!match) {
+      return word;
+    }
+
+    const [, prefix = "", core = "", suffix = ""] = match;
+    if (!core) {
+      capitalizeNext = SUBTITLE_SEPARATOR_PATTERN.test(word);
+      return word;
+    }
+
+    const isLastWord = index === words.length - 1;
+    const formattedCore = formatWordCore(core, capitalizeNext, isLastWord);
+    capitalizeNext = SUBTITLE_SEPARATOR_PATTERN.test(`${core}${suffix}`);
+
+    return `${prefix}${formattedCore}${suffix}`;
+  });
+
+  return restoreProtectedPhrases(formatted.join(" "));
+}
+
+export function getThesisTitleStandardization(value: unknown) {
+  const original = typeof value === "string" ? value.trim().replace(/\s+/g, " ") : "";
+  const standardized = formatApaThesisTitle(original);
+
+  return {
+    original,
+    standardized,
+    isChanged: Boolean(original && standardized && original !== standardized),
+  };
+}


### PR DESCRIPTION
## Summary
- adds a shared frontend APA thesis-title formatter aligned with the backend formatter branch
- shows standardized thesis title previews during student registration and admin verification
- lets students/admins apply the standardized value without retyping
- submits/saves the standardized value while keeping the raw input editable until review

## Validation
- npm run lint
- npm run build
- git diff --check

## Issue
Addresses the frontend portion of #154. Backend canonical storage remains the source of truth.

This draft targets `integration/all-six-refactor-preview` and should be reviewed by Koi before merge.